### PR TITLE
Redesign site with warm editorial layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
    <title>Luis Meraz | Actor</title>
    <meta name="description"
       content="Luis Meraz is a bilingual Mexican American actor in Los Angeles who acts, improvises, clowns, writes, and produces theater and shorts through Do Tell.">
-   <meta name="theme-color" content="#fffdf9">
+   <meta name="theme-color" content="#faf6f1">
    <link rel="canonical" href="https://luismeraz.com/">
    <meta property="og:type" content="website">
    <meta property="og:site_name" content="Luis Meraz">
@@ -30,11 +30,10 @@
    <link rel="manifest" href="site.webmanifest">
    <link rel="preconnect" href="https://fonts.googleapis.com">
    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet">
-   <link rel="stylesheet" href="styles.css">
    <link
-      href="https://fonts.googleapis.com/css2?family=Raleway:wght@400&family=Montserrat:wght@600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Syne:wght@400;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;1,8..60,300;1,8..60,400&display=swap"
       rel="stylesheet">
+   <link rel="stylesheet" href="styles.css">
    <script type="application/ld+json">
       {
          "@context": "https://schema.org",
@@ -99,227 +98,249 @@
          <path d="M8 6.5v11l9-5.5-9-5.5z" />
       </symbol>
    </svg>
+
+   <div class="grain" aria-hidden="true"></div>
+
    <a class="skip-link" href="#main-content">Skip to content</a>
-   <div class="container-fluid g-0">
-      <main id="main-content">
-         <section aria-labelledby="page-title">
-            <div class="row g-0 landing-row">
-               <div class="col-md-6 d-flex align-items-center justify-content-center img-container">
-                  <picture class="hero-picture">
+
+   <header class="site-header">
+      <nav aria-label="Primary">
+         <ul class="nav-list">
+            <li><a href="#about" class="nav-link">About</a></li>
+            <li><a href="#media" class="nav-link">Media</a></li>
+            <li><a href="#resume" class="nav-link">Resume</a></li>
+            <li><a href="#contact" class="nav-link">Contact</a></li>
+         </ul>
+      </nav>
+   </header>
+
+   <main id="main-content">
+      <section class="hero" aria-labelledby="page-title">
+         <div class="hero__image">
+            <picture class="hero-picture">
+               <source type="image/avif"
+                  srcset="images/optimized/headshots/luis-meraz-headshot-theatrical-900.avif 900w, images/optimized/headshots/luis-meraz-headshot-theatrical-1600.avif 1600w"
+                  sizes="100vw">
+               <img src="images/optimized/headshots/luis-meraz-headshot-theatrical-1600.jpg"
+                  srcset="images/optimized/headshots/luis-meraz-headshot-theatrical-900.jpg 900w, images/optimized/headshots/luis-meraz-headshot-theatrical-1600.jpg 1600w"
+                  sizes="100vw" width="4686" height="5858"
+                  alt="Luis Meraz theatrical headshot" class="hero-media" fetchpriority="high"
+                  decoding="async">
+            </picture>
+            <div class="hero__vignette"></div>
+         </div>
+         <div class="hero__text">
+            <p class="hero__label reveal">Actor</p>
+            <h1 id="page-title" class="hero__name reveal">Luis<br>Meraz</h1>
+            <p class="hero__location reveal">Los Angeles</p>
+         </div>
+         <div class="hero__scroll-hint" aria-hidden="true">
+            <span class="hero__scroll-line"></span>
+         </div>
+      </section>
+
+      <section id="about" class="section section--about" aria-labelledby="about-heading">
+         <div class="section__inner">
+            <span class="section__number reveal">01</span>
+            <h2 id="about-heading" class="section__heading reveal">About</h2>
+            <div class="about__grid">
+               <div class="about__text reveal">
+                  <p>I'm Luis, a bilingual Mexican American actor passionate about storytelling. I used to code at Meta
+                     and Lyft. I now inspire people to lead with courage, love, and joy through delight in my craft. I
+                     act, improvise, clown, and write. My production company, Do Tell, produces theater and shorts with
+                     rave reviews. Beyond entertainment, I surf, sail, DJ, and hike with my dog, Manny.</p>
+               </div>
+               <div class="about__image reveal">
+                  <picture class="about-picture">
                      <source type="image/avif"
-                        srcset="images/optimized/headshots/luis-meraz-headshot-theatrical-900.avif 900w, images/optimized/headshots/luis-meraz-headshot-theatrical-1600.avif 1600w"
-                        sizes="(max-width: 767px) 100vw, 50vw">
-                     <img src="images/optimized/headshots/luis-meraz-headshot-theatrical-1600.jpg"
-                        srcset="images/optimized/headshots/luis-meraz-headshot-theatrical-900.jpg 900w, images/optimized/headshots/luis-meraz-headshot-theatrical-1600.jpg 1600w"
-                        sizes="(max-width: 767px) 100vw, 50vw" width="4686" height="5858"
-                        alt="Luis Meraz theatrical headshot" class="hero-media" fetchpriority="high"
+                        srcset="images/optimized/photos/luis-mouth-480.avif 480w, images/optimized/photos/luis-mouth-960.avif 960w"
+                        sizes="(max-width: 767px) 80vw, 40vw">
+                     <img src="images/optimized/photos/luis-mouth-960.jpg"
+                        srcset="images/optimized/photos/luis-mouth-480.jpg 480w, images/optimized/photos/luis-mouth-960.jpg 960w"
+                        sizes="(max-width: 767px) 80vw, 40vw" width="5464" height="8192"
+                        class="about-media" alt="Luis Meraz smiling in a close-up portrait"
+                        loading="lazy" decoding="async">
+                  </picture>
+               </div>
+            </div>
+         </div>
+      </section>
+
+      <section id="media" class="section section--media" aria-labelledby="media-heading">
+         <div class="section__inner">
+            <span class="section__number reveal">02</span>
+            <h2 id="media-heading" class="section__heading reveal">Media</h2>
+
+            <h3 class="media__subheading reveal">Reels</h3>
+            <div class="reels__grid">
+               <a class="reel-card reveal" href="https://vimeo.com/1130100675" target="_blank" rel="noopener noreferrer"
+                  data-vimeo-id="1130100675" data-vimeo-hash="7a233520f4"
+                  data-vimeo-title="Luis Meraz comedy reel" aria-label="Play Luis Meraz comedy reel">
+                  <picture class="reel-picture">
+                     <source type="image/webp"
+                        srcset="https://i.vimeocdn.com/video/2074097254-ef6aef6271b526162af24420351be4343403e89c2d7a57b255cb0b6890fe8f01-d?f=webp&amp;mw=960&amp;q=85">
+                     <img
+                        src="https://i.vimeocdn.com/video/2074097254-ef6aef6271b526162af24420351be4343403e89c2d7a57b255cb0b6890fe8f01-d?mw=960&amp;q=85"
+                        width="960" height="540"
+                        class="reel-poster" alt="Luis Meraz comedy reel preview" loading="lazy"
+                        decoding="async">
+                  </picture>
+                  <span class="reel-card__overlay" aria-hidden="true">
+                     <span class="reel-card__label">Comedy</span>
+                     <span class="reel-card__play">
+                        <svg class="reel-card__play-icon" aria-hidden="true" focusable="false">
+                           <use href="#icon-play" />
+                        </svg>
+                     </span>
+                  </span>
+               </a>
+               <a class="reel-card reveal" href="https://vimeo.com/1130100691" target="_blank" rel="noopener noreferrer"
+                  data-vimeo-id="1130100691" data-vimeo-hash="9eab30c515"
+                  data-vimeo-title="Luis Meraz dramatic reel" aria-label="Play Luis Meraz dramatic reel">
+                  <picture class="reel-picture">
+                     <source type="image/webp"
+                        srcset="https://i.vimeocdn.com/video/2074097561-483022c7faaf89671864d48981f573f8f00b1d69cd234abe0402ae341108606e-d?f=webp&amp;mw=960&amp;q=85">
+                     <img
+                        src="https://i.vimeocdn.com/video/2074097561-483022c7faaf89671864d48981f573f8f00b1d69cd234abe0402ae341108606e-d?mw=960&amp;q=85"
+                        width="960" height="540"
+                        class="reel-poster" alt="Luis Meraz dramatic reel preview" loading="lazy"
+                        decoding="async">
+                  </picture>
+                  <span class="reel-card__overlay" aria-hidden="true">
+                     <span class="reel-card__label">Drama</span>
+                     <span class="reel-card__play">
+                        <svg class="reel-card__play-icon" aria-hidden="true" focusable="false">
+                           <use href="#icon-play" />
+                        </svg>
+                     </span>
+                  </span>
+               </a>
+            </div>
+
+            <h3 class="media__subheading reveal">Photos</h3>
+            <div class="gallery">
+               <div class="gallery__item reveal">
+                  <picture class="gallery-picture">
+                     <source type="image/avif" srcset="images/optimized/photos/luis-sailing-640.avif">
+                     <img src="images/optimized/photos/luis-sailing-640.jpg" width="1536" height="2048"
+                        class="gallery-media" alt="Luis Meraz sailing on the water" loading="lazy"
                         decoding="async">
                   </picture>
                </div>
-               <div class="col-md-6 d-flex align-items-center justify-content-center nav-right">
-                  <div class="text-center">
-                     <h2 class="actor-title">Actor</h2>
-                     <h1 id="page-title" class="actor-name">Luis Meraz</h1>
-                     <p class="actor-location">Los Angeles</p>
-                     <nav aria-label="Primary">
-                        <ul class="nav justify-content-center">
-                           <li class="nav-item mx-2"><a href="#about" class="nav-link">About</a></li>
-                           <li class="nav-item mx-2"><a href="#media" class="nav-link">Media</a></li>
-                           <li class="nav-item mx-2"><a href="#resume" class="nav-link">Resume</a></li>
-                           <li class="nav-item mx-2"><a href="#contact" class="nav-link">Contact</a></li>
-                        </ul>
-                     </nav>
-                  </div>
+               <div class="gallery__item reveal">
+                  <picture class="gallery-picture">
+                     <source type="image/avif" srcset="images/optimized/photos/do-tell-warm-up-640.avif">
+                     <img src="images/optimized/photos/do-tell-warm-up-640.jpg" width="4160" height="5335"
+                        class="gallery-media" alt="Luis Meraz leading a Do Tell warm-up" loading="lazy"
+                        decoding="async">
+                  </picture>
+               </div>
+               <div class="gallery__item reveal">
+                  <picture class="gallery-picture">
+                     <source type="image/avif" srcset="images/optimized/photos/luis-surfing-384.avif">
+                     <img src="images/optimized/photos/luis-surfing-384.jpg" width="384" height="678"
+                        class="gallery-media" alt="Luis Meraz surfing in open water" loading="lazy"
+                        decoding="async">
+                  </picture>
+               </div>
+               <div class="gallery__item reveal">
+                  <picture class="gallery-picture">
+                     <source type="image/avif" srcset="images/optimized/photos/luis-zach-smackdown-breath-640.avif">
+                     <img src="images/optimized/photos/luis-zach-smackdown-breath-640.jpg" width="4160"
+                        height="5436" class="gallery-media"
+                        alt="Luis Meraz and Zach performing in Smackdown" loading="lazy"
+                        decoding="async">
+                  </picture>
+               </div>
+               <div class="gallery__item reveal">
+                  <picture class="gallery-picture">
+                     <source type="image/avif" srcset="images/optimized/photos/do-tell-directing-640.avif">
+                     <img src="images/optimized/photos/do-tell-directing-640.jpg" width="4160" height="6240"
+                        class="gallery-media" alt="Luis Meraz directing a Do Tell production" loading="lazy"
+                        decoding="async">
+                  </picture>
+               </div>
+               <div class="gallery__item reveal">
+                  <picture class="gallery-picture">
+                     <source type="image/avif" srcset="images/optimized/photos/luis-zach-smackdown-stunned-640.avif">
+                     <img src="images/optimized/photos/luis-zach-smackdown-stunned-640.jpg" width="3758"
+                        height="5215" class="gallery-media"
+                        alt="Luis Meraz and Zach reacting in Smackdown" loading="lazy"
+                        decoding="async">
+                  </picture>
                </div>
             </div>
-         </section>
-         <section id="about" class="py-5 text-center" aria-labelledby="about-heading">
-            <div class="container">
-               <h2 id="about-heading">About Me</h2>
-               <div class="row align-items-center">
-                  <div class="col-md-6">
-                     <p>I’m Luis, a bilingual Mexican American actor passionate about storytelling. I used to code at Meta
-                        and Lyft. I now inspire people to lead with courage, love, and joy through delight in my craft. I
-                        act, improvise, clown, and write. My production company, Do Tell, produces theater and shorts with
-                        rave reviews. Beyond entertainment, I surf, sail, DJ, and hike with my dog, Manny.</p>
-                  </div>
-                  <div class="col-md-6">
-                     <picture class="about-picture">
-                        <source type="image/avif"
-                           srcset="images/optimized/photos/luis-mouth-480.avif 480w, images/optimized/photos/luis-mouth-960.avif 960w"
-                           sizes="(max-width: 767px) 60vw, 30vw">
-                        <img src="images/optimized/photos/luis-mouth-960.jpg"
-                           srcset="images/optimized/photos/luis-mouth-480.jpg 480w, images/optimized/photos/luis-mouth-960.jpg 960w"
-                           sizes="(max-width: 767px) 60vw, 30vw" width="5464" height="8192"
-                           class="about-media rounded" alt="Luis Meraz smiling in a close-up portrait"
-                           loading="lazy" decoding="async">
-                     </picture>
-                  </div>
-               </div>
-            </div>
-         </section>
-         <section id="media" class="py-5 text-center" aria-labelledby="media-heading">
-            <div class="container">
-               <h2 id="media-heading">Media</h2>
-               <h3>Reels</h3>
-                  <div class="row mb-5">
-                     <div class="col-md-6">
-                        <a class="reel-card" href="https://vimeo.com/1130100675" target="_blank" rel="noopener noreferrer"
-                           data-vimeo-id="1130100675" data-vimeo-hash="7a233520f4"
-                           data-vimeo-title="Luis Meraz comedy reel" aria-label="Play Luis Meraz comedy reel">
-                           <picture class="reel-picture">
-                              <source type="image/webp"
-                                 srcset="https://i.vimeocdn.com/video/2074097254-ef6aef6271b526162af24420351be4343403e89c2d7a57b255cb0b6890fe8f01-d?f=webp&amp;mw=960&amp;q=85">
-                              <img
-                                 src="https://i.vimeocdn.com/video/2074097254-ef6aef6271b526162af24420351be4343403e89c2d7a57b255cb0b6890fe8f01-d?mw=960&amp;q=85"
-                                 width="960" height="540"
-                                 class="reel-poster" alt="Luis Meraz comedy reel preview" loading="lazy"
-                                 decoding="async">
-                           </picture>
-                           <span class="reel-card__overlay" aria-hidden="true">
-                              <span class="reel-card__label">Comedy</span>
-                              <span class="reel-card__play">
-                                 <svg class="reel-card__play-icon" aria-hidden="true" focusable="false">
-                                    <use href="#icon-play" />
-                                 </svg>
-                              </span>
-                           </span>
-                        </a>
-                     </div>
-                     <div class="col-md-6">
-                        <a class="reel-card" href="https://vimeo.com/1130100691" target="_blank" rel="noopener noreferrer"
-                           data-vimeo-id="1130100691" data-vimeo-hash="9eab30c515"
-                           data-vimeo-title="Luis Meraz dramatic reel" aria-label="Play Luis Meraz dramatic reel">
-                           <picture class="reel-picture">
-                              <source type="image/webp"
-                                 srcset="https://i.vimeocdn.com/video/2074097561-483022c7faaf89671864d48981f573f8f00b1d69cd234abe0402ae341108606e-d?f=webp&amp;mw=960&amp;q=85">
-                              <img
-                                 src="https://i.vimeocdn.com/video/2074097561-483022c7faaf89671864d48981f573f8f00b1d69cd234abe0402ae341108606e-d?mw=960&amp;q=85"
-                                 width="960" height="540"
-                                 class="reel-poster" alt="Luis Meraz dramatic reel preview" loading="lazy"
-                                 decoding="async">
-                           </picture>
-                           <span class="reel-card__overlay" aria-hidden="true">
-                              <span class="reel-card__label">Drama</span>
-                              <span class="reel-card__play">
-                                 <svg class="reel-card__play-icon" aria-hidden="true" focusable="false">
-                                    <use href="#icon-play" />
-                                 </svg>
-                              </span>
-                           </span>
-                        </a>
-                     </div>
-                  </div>
-               <h3 class="text-center mt-5">Photos</h3>
-                  <div class="row g-0">
-                     <div class="col-md-2 col-sm-3 p-0 photo-tile">
-                        <picture class="gallery-picture">
-                           <source type="image/avif" srcset="images/optimized/photos/luis-sailing-640.avif">
-                           <img src="images/optimized/photos/luis-sailing-640.jpg" width="1536" height="2048"
-                              class="gallery-media" alt="Luis Meraz sailing on the water" loading="lazy"
-                              decoding="async">
-                        </picture>
-                     </div>
-                     <div class="col-md-2 col-sm-3 p-0 photo-tile">
-                        <picture class="gallery-picture">
-                           <source type="image/avif" srcset="images/optimized/photos/do-tell-warm-up-640.avif">
-                           <img src="images/optimized/photos/do-tell-warm-up-640.jpg" width="4160" height="5335"
-                              class="gallery-media" alt="Luis Meraz leading a Do Tell warm-up" loading="lazy"
-                              decoding="async">
-                        </picture>
-                     </div>
-                     <div class="col-md-2 col-sm-3 p-0 photo-tile">
-                        <picture class="gallery-picture">
-                           <source type="image/avif" srcset="images/optimized/photos/luis-surfing-384.avif">
-                           <img src="images/optimized/photos/luis-surfing-384.jpg" width="384" height="678"
-                              class="gallery-media" alt="Luis Meraz surfing in open water" loading="lazy"
-                              decoding="async">
-                        </picture>
-                     </div>
-                     <div class="col-md-2 col-sm-3 p-0 photo-tile">
-                        <picture class="gallery-picture">
-                           <source type="image/avif" srcset="images/optimized/photos/luis-zach-smackdown-breath-640.avif">
-                           <img src="images/optimized/photos/luis-zach-smackdown-breath-640.jpg" width="4160"
-                              height="5436" class="gallery-media"
-                              alt="Luis Meraz and Zach performing in Smackdown" loading="lazy"
-                              decoding="async">
-                        </picture>
-                     </div>
-                     <div class="col-md-2 col-sm-3 p-0 photo-tile">
-                        <picture class="gallery-picture">
-                           <source type="image/avif" srcset="images/optimized/photos/do-tell-directing-640.avif">
-                           <img src="images/optimized/photos/do-tell-directing-640.jpg" width="4160" height="6240"
-                              class="gallery-media" alt="Luis Meraz directing a Do Tell production" loading="lazy"
-                              decoding="async">
-                        </picture>
-                     </div>
-                     <div class="col-md-2 col-sm-3 p-0 photo-tile">
-                        <picture class="gallery-picture">
-                           <source type="image/avif" srcset="images/optimized/photos/luis-zach-smackdown-stunned-640.avif">
-                           <img src="images/optimized/photos/luis-zach-smackdown-stunned-640.jpg" width="3758"
-                              height="5215" class="gallery-media"
-                              alt="Luis Meraz and Zach reacting in Smackdown" loading="lazy"
-                              decoding="async">
-                        </picture>
-                     </div>
-                  </div>
-            </div>
-         </section>
-         <section id="resume" class="py-5 text-center" aria-labelledby="resume-heading">
-            <div class="container">
-               <h2 id="resume-heading">Resume</h2>
-               <iframe src="files/luis-meraz-actor-resume.pdf#toolbar=0" title="Luis Meraz acting resume PDF"
-                  class="resume-frame" loading="lazy"></iframe>
-            </div>
-            <a href="files/luis-meraz-actor-resume.pdf" class="btn btn-custom">Download Resume</a>
-         </section>
-         <section id="contact" class="py-5 text-center" aria-labelledby="contact-heading">
-            <div class="container">
-               <h2 id="contact-heading">Contact</h2>
-               <p>@itsluismeraz</p>
-               <a href="mailto:contact@luismeraz.com">contact@luismeraz.com</a>
-            </div>
-         </section>
-      </main>
-      <footer class="bg-dark text-white py-4">
-         <div class="container text-center">
-            <ul class="list-inline mb-0">
-               <li class="list-inline-item">
-                  <a class="text-white footer-social-link" href="https://www.imdb.com/name/nm16037724/"
-                     aria-label="Luis Meraz on IMDb" rel="noopener noreferrer">
-                     <svg class="footer-icon footer-icon--imdb" viewBox="0 0 448 512" aria-hidden="true"
-                        focusable="false">
-                        <path
-                           d="M89.5 323.6H53.93V186.2H89.5V323.6zM156.1 250.5L165.2 186.2H211.5V323.6H180.5V230.9L167.1 323.6H145.8L132.8 232.9L132.7 323.6H101.5V186.2H147.6C148.1 194.5 150.4 204.3 151.9 215.6L156.1 250.5zM223.7 323.6V186.2H250.3C267.3 186.2 277.3 187.1 283.3 188.6C289.4 190.3 294 192.8 297.2 196.5C300.3 199.8 302.3 203.1 303 208.5C303.9 212.9 304.4 221.6 304.4 234.7V282.9C304.4 295.2 303.7 303.4 302.5 307.6C301.4 311.7 299.4 315 296.5 317.3C293.7 319.7 290.1 321.4 285.8 322.3C281.6 323.1 275.2 323.6 266.7 323.6H223.7zM259.2 209.7V299.1C264.3 299.1 267.5 298.1 268.6 296.8C269.7 294.8 270.4 289.2 270.4 280.1V226.8C270.4 220.6 270.3 216.6 269.7 214.8C269.4 213 268.5 211.8 267.1 210.1C265.7 210.1 263 209.7 259.2 209.7V209.7zM316.5 323.6V186.2H350.6V230.1C353.5 227.7 356.7 225.2 360.1 223.5C363.7 222 368.9 221.1 372.9 221.1C377.7 221.1 381.8 221.9 385.2 223.3C388.6 224.8 391.2 226.8 393.2 229.5C394.9 232.1 395.9 234.8 396.3 237.3C396.7 239.9 396.1 245.3 396.1 253.5V292.1C396.1 300.3 396.3 306.4 395.3 310.5C394.2 314.5 391.5 318.1 387.5 320.1C383.4 324 378.6 325.4 372.9 325.4C368.9 325.4 363.7 324.5 360.2 322.9C356.7 321.1 353.5 318.4 350.6 314.9L348.5 323.6L316.5 323.6zM361.6 302.9C362.3 301.1 362.6 296.9 362.6 290.4V255C362.6 249.4 362.3 245.5 361.5 243.8C360.8 241.9 357.8 241.1 355.7 241.1C353.7 241.1 352.3 241.9 351.6 243.4C351 244.9 350.6 248.8 350.6 255V291.4C350.6 297.5 351 301.4 351.8 303C352.4 304.7 353.9 305.5 355.9 305.5C358.1 305.5 360.1 304.7 361.6 302.9L361.6 302.9zM418.4 32.04C434.1 33.27 447.1 47.28 447.1 63.92V448.1C447.1 464.5 435.2 478.5 418.9 479.1C418.6 479.1 418.4 480 418.1 480H29.88C29.6 480 29.32 479.1 29.04 479.9C13.31 478.5 1.093 466.1 0 449.7L.0186 61.78C1.081 45.88 13.82 33.09 30.26 31.1H417.7C417.9 31.1 418.2 32.01 418.4 32.04L418.4 32.04zM30.27 41.26C19 42.01 10.02 51.01 9.257 62.4V449.7C9.63 455.1 11.91 460.2 15.7 464C19.48 467.9 24.51 470.3 29.89 470.7H418.1C429.6 469.7 438.7 459.1 438.7 448.1V63.91C438.7 58.17 436.6 52.65 432.7 48.45C428.8 44.24 423.4 41.67 417.7 41.26L30.27 41.26z">
-                        </path>
-                     </svg>
-                  </a>
-               </li>
-               <li class="list-inline-item">
-                  <a class="text-white footer-social-link" href="https://www.instagram.com/itsluismeraz"
-                     aria-label="Luis Meraz on Instagram" rel="noopener noreferrer">
-                     <svg class="footer-icon" viewBox="0 0 448 512" aria-hidden="true" focusable="false">
-                        <path
-                           d="M224.1 141c-63.6 0-114.9 51.3-114.9 114.9s51.3 114.9 114.9 114.9S339 319.5 339 255.9 287.7 141 224.1 141zm0 189.6c-41.1 0-74.7-33.5-74.7-74.7s33.5-74.7 74.7-74.7 74.7 33.5 74.7 74.7-33.6 74.7-74.7 74.7zm146.4-194.3c0 14.9-12 26.8-26.8 26.8-14.9 0-26.8-12-26.8-26.8s12-26.8 26.8-26.8 26.8 12 26.8 26.8zm76.1 27.2c-1.7-35.9-9.9-67.7-36.2-93.9-26.2-26.2-58-34.4-93.9-36.2-37-2.1-147.9-2.1-184.9 0-35.8 1.7-67.6 9.9-93.9 36.1s-34.4 58-36.2 93.9c-2.1 37-2.1 147.9 0 184.9 1.7 35.9 9.9 67.7 36.2 93.9s58 34.4 93.9 36.2c37 2.1 147.9 2.1 184.9 0 35.9-1.7 67.7-9.9 93.9-36.2 26.2-26.2 34.4-58 36.2-93.9 2.1-37 2.1-147.8 0-184.8zM398.8 388c-7.8 19.6-22.9 34.7-42.6 42.6-29.5 11.7-99.5 9-132.1 9s-102.7 2.6-132.1-9c-19.6-7.8-34.7-22.9-42.6-42.6-11.7-29.5-9-99.5-9-132.1s-2.6-102.7 9-132.1c7.8-19.6 22.9-34.7 42.6-42.6 29.5-11.7 99.5-9 132.1-9s102.7-2.6 132.1 9c19.6 7.8 34.7 22.9 42.6 42.6 11.7 29.5 9 99.5 9 132.1s2.7 102.7-9 132.1z">
-                        </path>
-                     </svg>
-                  </a>
-               </li>
-               <li class="list-inline-item">
-                  <a class="text-white footer-social-link" href="https://www.tiktok.com/@itsluismeraz"
-                     aria-label="Luis Meraz on TikTok" rel="noopener noreferrer">
-                     <svg class="footer-icon" viewBox="0 0 448 512" aria-hidden="true" focusable="false">
-                        <path
-                           d="M448,209.91a210.06,210.06,0,0,1-122.77-39.25V349.38A162.55,162.55,0,1,1,185,188.31V278.2a74.62,74.62,0,1,0,52.23,71.18V0l88,0a121.18,121.18,0,0,0,1.86,22.17h0A122.18,122.18,0,0,0,381,102.39a121.43,121.43,0,0,0,67,20.14Z">
-                        </path>
-                     </svg>
-                  </a>
-               </li>
-            </ul>
-            <p class="mb-0 mt-2">&#169; <span id="copyright-year">2026</span> Luis Meraz. All rights reserved.</p>
          </div>
-      </footer>
-   </div>
+      </section>
+
+      <section id="resume" class="section section--resume" aria-labelledby="resume-heading">
+         <div class="section__inner">
+            <span class="section__number reveal">03</span>
+            <h2 id="resume-heading" class="section__heading reveal">Resume</h2>
+            <div class="resume__wrap reveal">
+               <iframe src="files/luis-meraz-actor-resume.pdf#toolbar=0" title="Luis Meraz acting resume PDF"
+                  class="resume-frame"></iframe>
+            </div>
+            <div class="resume__action reveal">
+               <a href="files/luis-meraz-actor-resume.pdf" class="btn-download">
+                  <span class="btn-download__text">Download Resume</span>
+                  <span class="btn-download__arrow">&darr;</span>
+               </a>
+            </div>
+         </div>
+      </section>
+
+      <section id="contact" class="section section--contact" aria-labelledby="contact-heading">
+         <div class="section__inner">
+            <span class="section__number reveal">04</span>
+            <h2 id="contact-heading" class="section__heading section__heading--large reveal">Let's<br>Work Together</h2>
+            <div class="contact__details reveal">
+               <p class="contact__handle">@itsluismeraz</p>
+               <a href="mailto:contact@luismeraz.com" class="contact__email">contact@luismeraz.com</a>
+            </div>
+         </div>
+      </section>
+   </main>
+
+   <footer class="site-footer">
+      <div class="footer__inner">
+         <ul class="footer__socials">
+            <li>
+               <a class="footer-social-link" href="https://www.imdb.com/name/nm16037724/"
+                  aria-label="Luis Meraz on IMDb" rel="noopener noreferrer">
+                  <svg class="footer-icon footer-icon--imdb" viewBox="0 0 448 512" aria-hidden="true"
+                     focusable="false">
+                     <path
+                        d="M89.5 323.6H53.93V186.2H89.5V323.6zM156.1 250.5L165.2 186.2H211.5V323.6H180.5V230.9L167.1 323.6H145.8L132.8 232.9L132.7 323.6H101.5V186.2H147.6C148.1 194.5 150.4 204.3 151.9 215.6L156.1 250.5zM223.7 323.6V186.2H250.3C267.3 186.2 277.3 187.1 283.3 188.6C289.4 190.3 294 192.8 297.2 196.5C300.3 199.8 302.3 203.1 303 208.5C303.9 212.9 304.4 221.6 304.4 234.7V282.9C304.4 295.2 303.7 303.4 302.5 307.6C301.4 311.7 299.4 315 296.5 317.3C293.7 319.7 290.1 321.4 285.8 322.3C281.6 323.1 275.2 323.6 266.7 323.6H223.7zM259.2 209.7V299.1C264.3 299.1 267.5 298.1 268.6 296.8C269.7 294.8 270.4 289.2 270.4 280.1V226.8C270.4 220.6 270.3 216.6 269.7 214.8C269.4 213 268.5 211.8 267.1 210.1C265.7 210.1 263 209.7 259.2 209.7V209.7zM316.5 323.6V186.2H350.6V230.1C353.5 227.7 356.7 225.2 360.1 223.5C363.7 222 368.9 221.1 372.9 221.1C377.7 221.1 381.8 221.9 385.2 223.3C388.6 224.8 391.2 226.8 393.2 229.5C394.9 232.1 395.9 234.8 396.3 237.3C396.7 239.9 396.1 245.3 396.1 253.5V292.1C396.1 300.3 396.3 306.4 395.3 310.5C394.2 314.5 391.5 318.1 387.5 320.1C383.4 324 378.6 325.4 372.9 325.4C368.9 325.4 363.7 324.5 360.2 322.9C356.7 321.1 353.5 318.4 350.6 314.9L348.5 323.6L316.5 323.6zM361.6 302.9C362.3 301.1 362.6 296.9 362.6 290.4V255C362.6 249.4 362.3 245.5 361.5 243.8C360.8 241.9 357.8 241.1 355.7 241.1C353.7 241.1 352.3 241.9 351.6 243.4C351 244.9 350.6 248.8 350.6 255V291.4C350.6 297.5 351 301.4 351.8 303C352.4 304.7 353.9 305.5 355.9 305.5C358.1 305.5 360.1 304.7 361.6 302.9L361.6 302.9zM418.4 32.04C434.1 33.27 447.1 47.28 447.1 63.92V448.1C447.1 464.5 435.2 478.5 418.9 479.1C418.6 479.1 418.4 480 418.1 480H29.88C29.6 480 29.32 479.1 29.04 479.9C13.31 478.5 1.093 466.1 0 449.7L.0186 61.78C1.081 45.88 13.82 33.09 30.26 31.1H417.7C417.9 31.1 418.2 32.01 418.4 32.04L418.4 32.04zM30.27 41.26C19 42.01 10.02 51.01 9.257 62.4V449.7C9.63 455.1 11.91 460.2 15.7 464C19.48 467.9 24.51 470.3 29.89 470.7H418.1C429.6 469.7 438.7 459.1 438.7 448.1V63.91C438.7 58.17 436.6 52.65 432.7 48.45C428.8 44.24 423.4 41.67 417.7 41.26L30.27 41.26z">
+                     </path>
+                  </svg>
+               </a>
+            </li>
+            <li>
+               <a class="footer-social-link" href="https://www.instagram.com/itsluismeraz"
+                  aria-label="Luis Meraz on Instagram" rel="noopener noreferrer">
+                  <svg class="footer-icon" viewBox="0 0 448 512" aria-hidden="true" focusable="false">
+                     <path
+                        d="M224.1 141c-63.6 0-114.9 51.3-114.9 114.9s51.3 114.9 114.9 114.9S339 319.5 339 255.9 287.7 141 224.1 141zm0 189.6c-41.1 0-74.7-33.5-74.7-74.7s33.5-74.7 74.7-74.7 74.7 33.5 74.7 74.7-33.6 74.7-74.7 74.7zm146.4-194.3c0 14.9-12 26.8-26.8 26.8-14.9 0-26.8-12-26.8-26.8s12-26.8 26.8-26.8 26.8 12 26.8 26.8zm76.1 27.2c-1.7-35.9-9.9-67.7-36.2-93.9-26.2-26.2-58-34.4-93.9-36.2-37-2.1-147.9-2.1-184.9 0-35.8 1.7-67.6 9.9-93.9 36.1s-34.4 58-36.2 93.9c-2.1 37-2.1 147.9 0 184.9 1.7 35.9 9.9 67.7 36.2 93.9s58 34.4 93.9 36.2c37 2.1 147.9 2.1 184.9 0 35.9-1.7 67.7-9.9 93.9-36.2 26.2-26.2 34.4-58 36.2-93.9 2.1-37 2.1-147.8 0-184.8zM398.8 388c-7.8 19.6-22.9 34.7-42.6 42.6-29.5 11.7-99.5 9-132.1 9s-102.7 2.6-132.1-9c-19.6-7.8-34.7-22.9-42.6-42.6-11.7-29.5-9-99.5-9-132.1s-2.6-102.7 9-132.1c7.8-19.6 22.9-34.7 42.6-42.6 29.5-11.7 99.5-9 132.1-9s102.7-2.6 132.1 9c19.6 7.8 34.7 22.9 42.6 42.6 11.7 29.5 9 99.5 9 132.1s2.7 102.7-9 132.1z">
+                     </path>
+                  </svg>
+               </a>
+            </li>
+            <li>
+               <a class="footer-social-link" href="https://www.tiktok.com/@itsluismeraz"
+                  aria-label="Luis Meraz on TikTok" rel="noopener noreferrer">
+                  <svg class="footer-icon" viewBox="0 0 448 512" aria-hidden="true" focusable="false">
+                     <path
+                        d="M448,209.91a210.06,210.06,0,0,1-122.77-39.25V349.38A162.55,162.55,0,1,1,185,188.31V278.2a74.62,74.62,0,1,0,52.23,71.18V0l88,0a121.18,121.18,0,0,0,1.86,22.17h0A122.18,122.18,0,0,0,381,102.39a121.43,121.43,0,0,0,67,20.14Z">
+                     </path>
+                  </svg>
+               </a>
+            </li>
+         </ul>
+         <p class="footer__copy">&copy; <span id="copyright-year">2026</span> Luis Meraz</p>
+      </div>
+   </footer>
+
    <script src="site.js" defer></script>
 </body>
 

--- a/site.js
+++ b/site.js
@@ -1,9 +1,29 @@
-const vimeoCards = document.querySelectorAll('[data-vimeo-id]');
-const copyrightYear = document.getElementById('copyright-year');
+/* ── Scroll reveal ──────────────────────────────────── */
+const reveals = document.querySelectorAll('.reveal:not(.hero .reveal)');
+const observer = new IntersectionObserver(
+  (entries) => {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('is-visible');
+        observer.unobserve(entry.target);
+      }
+    }
+  },
+  { threshold: 0.15, rootMargin: '0px 0px -40px 0px' }
+);
 
+for (const el of reveals) {
+  observer.observe(el);
+}
+
+/* ── Copyright year ────────────────────────────────── */
+const copyrightYear = document.getElementById('copyright-year');
 if (copyrightYear) {
   copyrightYear.textContent = String(new Date().getFullYear());
 }
+
+/* ── Vimeo embed ───────────────────────────────────── */
+const vimeoCards = document.querySelectorAll('[data-vimeo-id]');
 
 function isModifiedClick(event) {
   return event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0;

--- a/styles.css
+++ b/styles.css
@@ -1,164 +1,356 @@
+/* ── Tokens ─────────────────────────────────────────── */
 :root {
-  --primary-color: #fffdf9;
-  --secondary-color: #d7ddd7;
-  --accent-color: #cfaea3;
-  --highlight-color: #252831;
-  --text-color: #17161a;
-  --focus-ring: var(--text-color);
-  --resume-color: #e6d9c9;
-  --nav-hover-color: #fff8f0;
-  --overlay-strong: rgba(17, 20, 28, 0.44);
-  --overlay-soft: rgba(17, 20, 28, 0.18);
-  --reel-ui-color: rgba(186, 186, 186, 0.88);
-  --reel-ui-line: rgba(186, 186, 186, 0.68);
-  --reel-ui-surface: rgba(186, 186, 186, 0.58);
-  --reel-ui-icon: rgba(110, 110, 110, 0.88);
+  --bg: #faf6f1;
+  --bg-warm: #f2ebe2;
+  --bg-surface: #ede5da;
+  --bg-accent: #e8cdb5;
+  --text: #1e1b18;
+  --text-muted: #6b6259;
+  --accent: #c7623d;
+  --accent-hover: #a94f2e;
+  --accent-soft: #e8926e;
+  --border: rgba(30, 27, 24, 0.12);
+  --focus-ring: var(--accent);
+  --font-display: 'Instrument Serif', serif;
+  --font-heading: 'Syne', sans-serif;
+  --font-body: 'Source Serif 4', serif;
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
 }
+
+/* ── Reset ─────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 html {
   min-height: 100%;
-  background-color: var(--primary-color);
+  background-color: var(--bg);
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
 }
 
 body {
   min-height: 100%;
-  margin: 0;
-  font-family: 'Raleway', sans-serif;
-  color: var(--text-color);
+  font-family: var(--font-body);
+  font-weight: 300;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--text);
+  background-color: var(--bg);
+  overflow-x: hidden;
 }
 
-main {
-  display: block;
+main { display: block; }
+img, svg { display: block; max-width: 100%; }
+[hidden] { display: none !important; }
+a { color: inherit; text-decoration: none; }
+ul { list-style: none; }
+
+/* ── Grain (subtle warmth) ─────────────────────────── */
+.grain {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+  opacity: 0.04;
+  background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwBAMAAAClLOS0AAAAElBMVEUAAAAAAAAAAAAAAAAAAAAAAADgKxmiAAAABnRSTlMFBQUFBQVMIbLVAAAASElEQVQ4y2MYBaNgGAMWIxgYmBgYGBkYGJkYGFmANAsDIwuQZmFhZGZiYWRmYmJgZmRmYGZgZmBhYGBgYWFiYRgFo2AUAAB2BwJ/cMOjNgAAAABJRU5ErkJggg==");
+  background-size: 48px;
 }
 
-img,
-svg {
-  display: block;
-}
-
-a {
-  color: inherit;
-}
-
+/* ── Skip link ─────────────────────────────────────── */
 .skip-link {
   position: absolute;
   top: 1rem;
   left: 1rem;
-  z-index: 1000;
+  z-index: 10000;
   padding: 0.75rem 1rem;
-  background-color: var(--highlight-color);
-  color: var(--accent-color);
+  background-color: var(--accent);
+  color: #fff;
+  font-family: var(--font-heading);
+  font-weight: 600;
   text-decoration: none;
   transform: translateY(-200%);
   transition: transform 0.2s ease;
 }
 
-.skip-link:focus {
-  transform: translateY(0);
-}
+.skip-link:focus { transform: translateY(0); }
 
+/* ── Focus styles ──────────────────────────────────── */
 .skip-link:focus-visible,
 .nav-link:focus-visible,
-.btn-custom:focus-visible,
+.btn-download:focus-visible,
 .reel-card:focus-visible,
 .footer-social-link:focus-visible,
-#contact a:focus-visible {
-  outline: 3px solid var(--focus-ring);
+.contact__email:focus-visible {
+  outline: 2px solid var(--focus-ring);
   outline-offset: 4px;
 }
 
-.landing-row,
-.img-container,
-.nav-right {
-  min-height: 100vh;
+/* ── Scroll reveal ─────────────────────────────────── */
+.reveal {
+  opacity: 0;
+  transform: translateY(1.5rem);
+  transition: opacity 0.7s var(--ease-out), transform 0.7s var(--ease-out);
 }
 
-.img-container {
-  background-color: var(--primary-color);
+.reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
-.hero-picture,
-.hero-media,
-.reel-picture,
-.reel-poster {
-  width: 100%;
-  height: 100%;
+/* ── Header / Nav ──────────────────────────────────── */
+.site-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  padding: 0.7rem 2rem;
+  background-color: rgba(30, 27, 24, 0.85);
+  display: flex;
+  justify-content: center;
 }
 
-.hero-picture,
-.about-picture,
-.gallery-picture {
-  display: block;
-}
-
-.hero-media {
-  object-fit: cover;
-}
-
-.nav-right,
-.btn-custom {
-  background-color: var(--highlight-color);
-  color: var(--accent-color);
-}
-
-.nav-right {
-  padding: 2rem 1.5rem;
+.nav-list {
+  display: flex;
+  gap: 2.25rem;
 }
 
 .nav-link {
-  color: var(--accent-color);
+  font-family: var(--font-heading);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(250, 246, 241, 0.65);
+  transition: color 0.3s ease;
+  position: relative;
+}
+
+.nav-link::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 0;
+  height: 1.5px;
+  background-color: var(--accent-soft);
+  transition: width 0.4s var(--ease-out);
 }
 
 .nav-link:hover,
 .nav-link:focus-visible {
-  color: var(--nav-hover-color);
+  color: #fff;
 }
 
-.btn-custom {
-  border: 1px solid var(--accent-color);
+.nav-link:hover::after,
+.nav-link:focus-visible::after {
+  width: 100%;
 }
 
-.btn-custom:hover {
-  background-color: var(--accent-color);
-  color: var(--highlight-color);
+/* ── Hero ──────────────────────────────────────────── */
+.hero {
+  position: relative;
+  height: 100dvh;
+  min-height: 550px;
+  display: flex;
+  align-items: flex-end;
+  overflow: hidden;
+  background-color: #2a2420;
 }
 
-section h2,
-section h3 {
-  font-family: 'Montserrat', sans-serif;
-  margin-bottom: 20px;
+.hero__image {
+  position: absolute;
+  inset: -1px;
 }
 
-#about {
-  background-color: var(--secondary-color);
+.hero-picture,
+.hero-media {
+  width: 100%;
+  height: 100%;
 }
 
-#resume {
-  background-color: var(--resume-color);
+.hero-media {
+  object-fit: cover;
+  object-position: center 50%;
 }
 
-#media {
-  background-color: var(--accent-color);
+.hero__vignette {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(30, 27, 24, 0.05) 0%,
+    rgba(30, 27, 24, 0.0) 40%,
+    rgba(30, 27, 24, 0.25) 70%,
+    rgba(30, 27, 24, 0.82) 100%
+  );
 }
 
-#contact {
-  background-color: var(--primary-color);
+.hero__text {
+  position: relative;
+  z-index: 2;
+  padding: 0 clamp(1.5rem, 5vw, 5rem) clamp(2rem, 6vh, 4rem);
+  width: 100%;
+}
+
+.hero__label {
+  font-family: var(--font-heading);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--accent-soft);
+  margin-bottom: 0.5rem;
+}
+
+.hero__name {
+  font-family: var(--font-display);
+  font-size: clamp(3.5rem, 11vw, 9rem);
+  font-weight: 400;
+  font-style: italic;
+  line-height: 0.9;
+  letter-spacing: -0.02em;
+  color: #fff;
+  margin-bottom: 0.5rem;
+  text-shadow: 0 2px 20px rgba(0,0,0,0.15);
+}
+
+.hero__location {
+  font-family: var(--font-heading);
+  font-size: 0.78rem;
+  font-weight: 400;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.65);
+}
+
+.hero__scroll-hint {
+  position: absolute;
+  bottom: 1.5rem;
+  right: clamp(1.5rem, 5vw, 5rem);
+  z-index: 2;
+}
+
+.hero__scroll-line {
+  display: block;
+  width: 1px;
+  height: 3rem;
+  background: linear-gradient(to bottom, transparent, rgba(255,255,255,0.5));
+  animation: scrollPulse 2s ease-in-out infinite;
+}
+
+@keyframes scrollPulse {
+  0%, 100% { opacity: 0.3; transform: scaleY(0.6); transform-origin: top; }
+  50% { opacity: 1; transform: scaleY(1); }
+}
+
+/* ── Hero initial animations ───────────────────────── */
+.hero .reveal {
+  opacity: 0;
+  transform: translateY(1.5rem);
+  animation: heroReveal 0.8s var(--ease-out) forwards;
+}
+
+@keyframes heroReveal {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.hero .reveal:nth-child(1) { animation-delay: 0.2s; }
+.hero .reveal:nth-child(2) { animation-delay: 0.4s; }
+.hero .reveal:nth-child(3) { animation-delay: 0.6s; }
+
+/* ── Sections ──────────────────────────────────────── */
+.section {
+  position: relative;
+  padding: clamp(2.5rem, 6vh, 4.5rem) 0;
+}
+
+.section__inner {
+  width: min(90%, 72rem);
+  margin: 0 auto;
+}
+
+.section__number {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  color: var(--accent-soft);
+  margin-bottom: 0.75rem;
+}
+
+.section__heading {
+  font-family: var(--font-display);
+  font-size: clamp(2.2rem, 5vw, 3.8rem);
+  font-weight: 400;
+  font-style: italic;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin-bottom: 1.75rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.section__heading--large {
+  font-size: clamp(2.5rem, 7vw, 5.5rem);
+  line-height: 0.95;
+  border-bottom: none;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0;
+}
+
+/* ── About ─────────────────────────────────────────── */
+.section--about {
+  background-color: var(--bg-warm);
+}
+
+.about__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(2rem, 4vw, 4rem);
+  align-items: center;
+}
+
+.about__text p {
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: var(--text);
+  max-width: 34rem;
 }
 
 .about-media {
-  display: block;
-  width: min(60%, 22rem);
+  width: 100%;
   height: auto;
-  margin: 20px auto;
+  border-radius: 4px;
+  transition: transform 0.5s var(--ease-out);
 }
 
-.resume-frame {
-  display: block;
-  width: min(80%, 56rem);
-  height: 300px;
-  margin: 0 auto 1.5rem;
-  border: 0;
-  background-color: #fff;
+.about-media:hover {
+  transform: scale(1.015);
+}
+
+/* ── Media ─────────────────────────────────────────── */
+.section--media {
+  background-color: var(--bg);
+}
+
+.media__subheading {
+  font-family: var(--font-heading);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+  margin-top: 0.5rem;
+}
+
+.reels__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  margin-bottom: 2.5rem;
 }
 
 .reel-card,
@@ -168,12 +360,23 @@ section h3 {
   width: 100%;
   aspect-ratio: 16 / 9;
   overflow: hidden;
-  background-color: #1a1a1a;
-  text-decoration: none;
+  background-color: #1a1718;
+  border-radius: 4px;
+}
+
+.reel-picture,
+.reel-poster {
+  width: 100%;
+  height: 100%;
 }
 
 .reel-poster {
   object-fit: cover;
+  transition: transform 0.6s var(--ease-out);
+}
+
+.reel-card:hover .reel-poster {
+  transform: scale(1.04);
 }
 
 .reel-card__overlay {
@@ -182,50 +385,54 @@ section h3 {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(180deg, var(--overlay-soft), var(--overlay-strong));
+  background: linear-gradient(180deg, rgba(30, 27, 24, 0.05), rgba(30, 27, 24, 0.45));
 }
 
 .reel-card__label {
   position: absolute;
   top: 1rem;
   left: 1rem;
-  z-index: 1;
+  font-family: var(--font-heading);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.8);
   display: inline-flex;
   align-items: center;
-  gap: 0.55rem;
-  color: var(--reel-ui-color);
-  font-family: 'Montserrat', sans-serif;
-  font-size: 0.95rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.38);
+  gap: 0.5rem;
+  text-shadow: 0 1px 4px rgba(0,0,0,0.2);
 }
 
 .reel-card__label::before {
-  content: "";
-  width: 1.5rem;
+  content: '';
+  width: 1.25rem;
   height: 1px;
-  background-color: var(--reel-ui-line);
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.24);
+  background-color: rgba(255,255,255,0.5);
 }
 
 .reel-card__play {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 4.25rem;
-  height: 4.25rem;
-  border-radius: 999px;
-  background-color: var(--reel-ui-surface);
-  color: var(--reel-ui-icon);
-  box-shadow: 0 10px 26px rgba(27, 30, 36, 0.18);
-  backdrop-filter: blur(3px);
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  border: 1.5px solid rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.2);
+  transition: transform 0.4s var(--ease-out), background-color 0.4s ease;
+}
+
+.reel-card:hover .reel-card__play {
+  transform: scale(1.1);
+  background-color: rgba(255, 255, 255, 0.28);
 }
 
 .reel-card__play-icon {
-  width: 2rem;
-  height: 2rem;
-  fill: currentColor;
+  width: 1.35rem;
+  height: 1.35rem;
+  fill: #fff;
+  margin-left: 2px;
 }
 
 .reel-frame iframe {
@@ -234,18 +441,148 @@ section h3 {
   border: 0;
 }
 
-.photo-tile {
-  display: flex;
-  justify-content: center;
+/* ── Gallery ───────────────────────────────────────── */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+}
+
+.gallery__item {
+  overflow: hidden;
+  border-radius: 3px;
 }
 
 .gallery-picture {
+  display: block;
   width: 100%;
 }
 
 .gallery-media {
   width: 100%;
-  height: auto;
+  height: 100%;
+  aspect-ratio: 3 / 4;
+  object-fit: cover;
+  transition: transform 0.6s var(--ease-out);
+}
+
+.gallery__item:nth-child(1) { transition-delay: 0s; }
+.gallery__item:nth-child(2) { transition-delay: 0.08s; }
+.gallery__item:nth-child(3) { transition-delay: 0.16s; }
+.gallery__item:nth-child(4) { transition-delay: 0.24s; }
+.gallery__item:nth-child(5) { transition-delay: 0.32s; }
+.gallery__item:nth-child(6) { transition-delay: 0.4s; }
+
+.gallery__item:hover .gallery-media {
+  transform: scale(1.04);
+}
+
+/* ── Resume ────────────────────────────────────────── */
+.section--resume {
+  background-color: var(--bg-surface);
+}
+
+.resume__wrap {
+  margin-bottom: 1.5rem;
+}
+
+.resume-frame {
+  display: block;
+  width: 100%;
+  max-width: 56rem;
+  height: 360px;
+  margin: 0 auto;
+  border: 0;
+  border-radius: 4px;
+  background-color: #fff;
+}
+
+.resume__action {
+  text-align: center;
+}
+
+.btn-download {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.85rem 2rem;
+  font-family: var(--font-heading);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  border: 1.5px solid var(--accent);
+  border-radius: 3px;
+  background: transparent;
+  transition: background-color 0.35s ease, color 0.35s ease;
+}
+
+.btn-download:hover {
+  background-color: var(--accent);
+  color: #fff;
+}
+
+.btn-download__arrow {
+  font-size: 1rem;
+  transition: transform 0.3s var(--ease-out);
+}
+
+.btn-download:hover .btn-download__arrow {
+  transform: translateY(2px);
+}
+
+/* ── Contact ───────────────────────────────────────── */
+.section--contact {
+  background-color: var(--bg-accent);
+  min-height: 50vh;
+  display: flex;
+  align-items: center;
+}
+
+.contact__details {
+  padding-top: 0.5rem;
+}
+
+.contact__handle {
+  font-family: var(--font-heading);
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.contact__email {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 3.5vw, 2.2rem);
+  font-style: italic;
+  color: var(--accent);
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.3s ease;
+}
+
+.contact__email:hover {
+  border-bottom-color: var(--accent);
+}
+
+/* ── Footer ────────────────────────────────────────── */
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 2rem 0;
+  background-color: var(--bg);
+}
+
+.footer__inner {
+  width: min(90%, 72rem);
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.footer__socials {
+  display: flex;
+  gap: 1rem;
 }
 
 .footer-social-link {
@@ -254,40 +591,96 @@ section h3 {
   justify-content: center;
   width: 2rem;
   height: 2rem;
-  text-decoration: none;
+  color: var(--text-muted);
+  transition: color 0.3s ease;
+}
+
+.footer-social-link:hover {
+  color: var(--accent);
 }
 
 .footer-icon {
-  width: 1.35rem;
-  height: 1.35rem;
+  width: 1.2rem;
+  height: 1.2rem;
   fill: currentColor;
 }
 
 .footer-icon--imdb {
-  width: 1.55rem;
+  width: 1.4rem;
 }
 
+.footer__copy {
+  font-family: var(--font-heading);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+}
+
+/* ── Responsive ────────────────────────────────────── */
 @media (max-width: 768px) {
-  .landing-row,
-  .nav-right {
-    min-height: auto;
+  .site-header {
+    padding: 0.6rem 1rem;
   }
 
-  .img-container {
-    min-height: 60vh;
-    height: 60vh;
+  .nav-list {
+    gap: 1.25rem;
   }
 
-  .nav-item {
-    margin: 0.625rem 0;
+  .hero {
+    min-height: 80vh;
+  }
+
+  .hero__name {
+    font-size: clamp(3rem, 14vw, 5.5rem);
+  }
+
+  .about__grid {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+
+  .about__text p {
+    font-size: 1rem;
+  }
+
+  .reels__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gallery {
+    grid-template-columns: repeat(2, 1fr);
   }
 
   .resume-frame {
-    width: 100%;
+    height: 280px;
   }
 
-  .gallery-picture {
-    width: 75%;
-    margin: 0.625rem auto;
+  .section__heading--large {
+    font-size: clamp(2.2rem, 9vw, 3.5rem);
+  }
+
+  .section--contact {
+    min-height: 40vh;
+  }
+
+  .footer__inner {
+    flex-direction: column;
+    gap: 0.75rem;
+    text-align: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .gallery {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+  }
+
+  .hero__name {
+    font-size: 3rem;
+  }
+
+  .section {
+    padding: 2.5rem 0;
   }
 }


### PR DESCRIPTION
## Summary
- Replace Bootstrap with custom CSS using Instrument Serif, Syne, and Source Serif 4 typography
- Full-bleed hero with vignette overlay, scroll-triggered reveal animations, and film grain texture
- Warm cream/terracotta color palette with editorial section numbering
- Fix hidden SVG sprite taking layout space (`[hidden] { display: none !important }`)
- Remove expensive `backdrop-filter` from header and reel play buttons
- Move gallery stagger delays from JS inline styles to CSS `nth-child` rules
- Remove unsupported `loading="lazy"` from resume iframe

## Test plan
- [ ] Verify hero image fills viewport with no gap above it
- [ ] Verify nav bar is visible and readable over the hero
- [ ] Verify scroll reveal animations trigger on all sections
- [ ] Verify Vimeo reel cards still embed on click
- [ ] Verify responsive layout on mobile (nav, gallery columns, about grid)
- [ ] Verify all images and links still work

🤖 Generated with [Claude Code](https://claude.ai/code)