### PR TITLE
feat: simplify theme to quiet single-font design

### DIFF
--- a/src/components/AuthorCard.astro
+++ b/src/components/AuthorCard.astro
@@ -30,7 +30,7 @@
     gap: 1.25rem;
     align-items: flex-start;
     padding: 1.5rem;
-    background-color: var(--bg-warm);
+    background-color: var(--bg-surface);
     border-radius: 4px;
     margin-top: 2rem;
   }
@@ -44,9 +44,8 @@
   }
 
   .author-card__name {
-    font-family: var(--font-heading);
-    font-size: 0.85rem;
     font-weight: 600;
+    font-size: 0.95rem;
     color: var(--text);
     margin-bottom: 0.2rem;
   }
@@ -58,25 +57,18 @@
     margin-bottom: 0.4rem;
   }
 
-  .author-card__bio a {
-    color: var(--accent);
-    border-bottom: 1px solid transparent;
-    transition: border-color 0.3s ease;
-  }
-
-  .author-card__bio a:hover { border-bottom-color: var(--accent); }
-
   .author-card__links {
-    font-family: var(--font-heading);
-    font-size: 0.68rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
+    font-size: 0.88rem;
     color: var(--text-muted);
     display: flex;
     gap: 0.4rem;
   }
 
-  .author-card__links a { color: var(--accent); }
+  .author-card__links a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    text-decoration-thickness: 1px;
+  }
   .author-card__sep { opacity: 0.5; }
 </style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -34,40 +34,31 @@ const socials = [
 <style>
   .site-footer {
     border-top: 1px solid var(--border);
-    padding: 2.5rem 0 2rem;
-    background-color: var(--bg);
-    transition: background-color 0.2s ease;
+    padding: 2rem 0;
   }
 
-  .footer__signup { margin-bottom: 2rem; }
+  .footer__signup { margin-bottom: 1.5rem; }
 
   .footer__bottom {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: baseline;
   }
 
   .footer__socials {
     display: flex;
-    gap: 1.25rem;
+    gap: 1rem;
   }
 
   .footer-social-link {
-    font-family: var(--font-heading);
-    font-size: 0.68rem;
-    font-weight: 600;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
+    font-size: 0.9rem;
     color: var(--text-muted);
-    transition: color 0.3s ease;
   }
 
   .footer-social-link:hover { color: var(--accent); }
 
   .footer__copy {
-    font-family: var(--font-heading);
-    font-size: 0.68rem;
-    letter-spacing: 0.1em;
+    font-size: 0.9rem;
     color: var(--text-muted);
   }
 

--- a/src/components/Gallery.astro
+++ b/src/components/Gallery.astro
@@ -16,7 +16,7 @@ const { photos } = Astro.props;
 
 <div class="gallery">
   {photos.map(photo => (
-    <div class="gallery__item reveal">
+    <div class="gallery__item">
       <picture>
         <source type="image/avif" srcset={photo.avif} />
         <img
@@ -43,9 +43,7 @@ const { photos } = Astro.props;
   .gallery-media {
     width: 100%; height: 100%;
     aspect-ratio: 3 / 4; object-fit: cover;
-    transition: transform 0.6s var(--ease-out);
   }
-  .gallery__item:hover .gallery-media { transform: scale(1.04); }
 
   @media (max-width: 768px) { .gallery { grid-template-columns: repeat(2, 1fr); } }
   @media (max-width: 480px) { .gallery { grid-template-columns: 1fr; } }

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -34,75 +34,49 @@ const links = [
 
 <style>
   .site-header {
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    padding: 0.75rem 0;
-    background-color: var(--bg);
+    padding: 1.25rem 0;
     border-bottom: 1px solid var(--border);
-    transition: background-color 0.2s ease;
   }
 
   .site-header__inner {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: baseline;
   }
 
   .site-logo {
-    font-family: var(--font-display);
-    font-size: 1.3rem;
-    font-style: italic;
+    font-weight: 600;
+    font-size: 1.05rem;
     color: var(--text);
-    text-decoration: none;
   }
 
   .nav-right {
     display: flex;
-    align-items: center;
-    gap: 1.5rem;
+    align-items: baseline;
+    gap: 1.25rem;
   }
 
   .nav-list {
     display: flex;
-    gap: 1.75rem;
+    gap: 1.25rem;
   }
 
   .nav-link {
-    font-family: var(--font-heading);
-    font-size: 0.7rem;
-    font-weight: 600;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
+    font-size: 0.95rem;
     color: var(--text-muted);
-    transition: color 0.3s ease;
-    position: relative;
   }
 
-  .nav-link::after {
-    content: '';
-    position: absolute;
-    bottom: -4px;
-    left: 0;
-    width: 0;
-    height: 1.5px;
-    background-color: var(--accent);
-    transition: width 0.4s var(--ease-out);
-  }
+  .nav-link:hover { color: var(--text); }
 
-  .nav-link:hover,
   .nav-link--active {
     color: var(--text);
+    text-decoration: underline;
+    text-underline-offset: 4px;
+    text-decoration-thickness: 1px;
   }
 
-  .nav-link:hover::after,
-  .nav-link--active::after {
-    width: 100%;
-  }
-
-  @media (max-width: 768px) {
+  @media (max-width: 480px) {
     .site-header__inner { flex-wrap: wrap; gap: 0.5rem; }
     .nav-list { gap: 1rem; }
-    .nav-link { font-size: 0.62rem; letter-spacing: 0.08em; }
   }
 </style>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -26,12 +26,12 @@ const displayTime = readingTime ?? 5;
   <a href={`/blog/${slug}`} class="post-card__link">
     <h3 class="post-card__title">{title}</h3>
   </a>
-  <div class="post-card__meta">
+  <div class="post-card__meta meta">
     <time datetime={pubDate.toISOString()}>{formattedDate}</time>
     <span class="post-card__sep">&middot;</span>
     <span>{displayTime} min read</span>
     <span class="post-card__sep">&middot;</span>
-    <span class="post-card__category">{category}</span>
+    <span>{category}</span>
   </div>
   <p class="post-card__description">{description}</p>
   <TagList tags={tags} />
@@ -43,18 +43,8 @@ const displayTime = readingTime ?? 5;
     border-bottom: 1px solid var(--border);
   }
 
-  .post-card__link {
-    text-decoration: none;
-  }
-
   .post-card__title {
-    font-family: var(--font-display);
-    font-size: 1.4rem;
-    font-weight: 400;
-    font-style: italic;
-    color: var(--text);
     margin-bottom: 0.3rem;
-    transition: color 0.3s ease;
   }
 
   .post-card__link:hover .post-card__title {
@@ -62,11 +52,6 @@ const displayTime = readingTime ?? 5;
   }
 
   .post-card__meta {
-    font-family: var(--font-heading);
-    font-size: 0.68rem;
-    font-weight: 400;
-    letter-spacing: 0.06em;
-    color: var(--text-muted);
     margin-bottom: 0.5rem;
     display: flex;
     align-items: center;
@@ -75,16 +60,10 @@ const displayTime = readingTime ?? 5;
 
   .post-card__sep { opacity: 0.5; }
 
-  .post-card__category {
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    font-weight: 600;
-  }
-
   .post-card__description {
-    font-size: 0.92rem;
+    font-size: 0.95rem;
     color: var(--text-muted);
     line-height: 1.6;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.6rem;
   }
 </style>

--- a/src/components/ReelCard.astro
+++ b/src/components/ReelCard.astro
@@ -46,37 +46,29 @@ const { vimeoId, vimeoHash, title, label, posterWebp, posterJpg } = Astro.props;
     border-radius: 4px;
   }
   .reel-picture, .reel-poster { width: 100%; height: 100%; }
-  .reel-poster { object-fit: cover; transition: transform 0.6s var(--ease-out); }
-  .reel-card:hover .reel-poster { transform: scale(1.04); }
+  .reel-poster { object-fit: cover; }
 
   .reel-card__overlay {
     position: absolute; inset: 0;
     display: flex; align-items: center; justify-content: center;
-    background: linear-gradient(180deg, rgba(30,27,24,0.05), rgba(30,27,24,0.45));
+    background: rgba(30, 27, 24, 0.25);
   }
 
   .reel-card__label {
     position: absolute; top: 1rem; left: 1rem;
-    font-family: var(--font-heading);
-    font-size: 0.68rem; font-weight: 600;
-    letter-spacing: 0.14em; text-transform: uppercase;
-    color: rgba(255,255,255,0.8);
-    display: inline-flex; align-items: center; gap: 0.5rem;
-    text-shadow: 0 1px 4px rgba(0,0,0,0.2);
-  }
-  .reel-card__label::before {
-    content: ''; width: 1.25rem; height: 1px;
-    background-color: rgba(255,255,255,0.5);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: rgba(255,255,255,0.9);
+    text-shadow: 0 1px 4px rgba(0,0,0,0.3);
   }
 
   .reel-card__play {
     display: flex; align-items: center; justify-content: center;
     width: 3.5rem; height: 3.5rem; border-radius: 50%;
-    border: 1.5px solid rgba(255,255,255,0.5);
+    border: 1px solid rgba(255,255,255,0.6);
     background-color: rgba(255,255,255,0.2);
-    transition: transform 0.4s var(--ease-out), background-color 0.4s ease;
   }
-  .reel-card:hover .reel-card__play { transform: scale(1.1); background-color: rgba(255,255,255,0.28); }
+  .reel-card:hover .reel-card__play { background-color: rgba(255,255,255,0.35); }
   .reel-card__play svg { margin-left: 2px; }
 </style>
 

--- a/src/components/SignupForm.astro
+++ b/src/components/SignupForm.astro
@@ -38,9 +38,8 @@ const {
 
 <style>
   .signup-form__heading {
-    font-family: var(--font-display);
-    font-size: 1.3rem;
-    font-style: italic;
+    font-weight: 600;
+    font-size: 1.15rem;
     color: var(--text);
     margin-bottom: 0.25rem;
   }
@@ -59,14 +58,13 @@ const {
 
   .signup-form__input {
     flex: 1;
-    padding: 0.7rem 1rem;
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
+    padding: 0.5rem 0.9rem;
+    font-family: var(--font-body);
+    font-size: 0.95rem;
     color: var(--text);
     background-color: var(--bg);
-    border: 1.5px solid var(--border);
+    border: 1px solid var(--border);
     border-radius: 3px;
-    transition: border-color 0.3s ease;
   }
 
   .signup-form__input::placeholder { color: var(--text-muted); }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -24,7 +24,7 @@ const props = Astro.props;
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="theme-color" content="#faf6f1" />
+  <meta name="theme-color" content="#faf7f2" />
 
   {/* Blocking script: prevent dark mode flash */}
   <script is:inline>
@@ -49,12 +49,11 @@ const props = Astro.props;
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
-    href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Syne:wght@400;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;1,8..60,300;1,8..60,400&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&display=swap"
     rel="stylesheet"
   />
 </head>
 <body>
-  <div class="grain" aria-hidden="true"></div>
   <a class="skip-link" href="#main-content">Skip to content</a>
 
   <Nav />
@@ -64,22 +63,5 @@ const props = Astro.props;
   </main>
 
   <Footer />
-
-  <script>
-    // Scroll reveal
-    const reveals = document.querySelectorAll('.reveal');
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('is-visible');
-            observer.unobserve(entry.target);
-          }
-        }
-      },
-      { threshold: 0.15, rootMargin: '0px 0px -40px 0px' }
-    );
-    for (const el of reveals) observer.observe(el);
-  </script>
 </body>
 </html>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -57,8 +57,8 @@ const displayTime = readingTime ?? 5;
     <div class="container">
       <div class="reading-width">
         <header class="blog-post__header">
-          <div class="blog-post__meta">
-            <span class="blog-post__category label">{category}</span>
+          <div class="blog-post__meta meta">
+            <span>{category}</span>
             <span class="blog-post__sep">&middot;</span>
             <time datetime={pubDate.toISOString()}>{formattedDate}</time>
             <span class="blog-post__sep">&middot;</span>
@@ -95,10 +95,6 @@ const displayTime = readingTime ?? 5;
   }
 
   .blog-post__meta {
-    font-family: var(--font-heading);
-    font-size: 0.7rem;
-    letter-spacing: 0.06em;
-    color: var(--text-muted);
     margin-bottom: 0.75rem;
     display: flex;
     align-items: center;
@@ -108,14 +104,13 @@ const displayTime = readingTime ?? 5;
   .blog-post__sep { opacity: 0.5; }
 
   .blog-post__title {
-    font-size: clamp(2rem, 5vw, 3rem);
     margin-bottom: 0.75rem;
   }
 
   .blog-post__updated {
-    font-family: var(--font-heading);
-    font-size: 0.7rem;
-    color: var(--accent);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--text-muted);
     margin-bottom: 0.75rem;
   }
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -7,17 +7,17 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   description="This page doesn't exist."
   noindex
 >
-  <section class="section" style="min-height: 50vh; display: flex; align-items: center;">
-    <div class="container" style="text-align: center;">
-      <p class="label" style="margin-bottom: 0.5rem;">404</p>
+  <section class="section">
+    <div class="container">
+      <p class="meta" style="margin-bottom: 0.5rem;">404</p>
       <h1 style="margin-bottom: 1rem;">Page not found</h1>
       <p style="color: var(--text-muted); margin-bottom: 1.5rem;">
         The page you're looking for doesn't exist or has moved.
       </p>
-      <div style="display: flex; gap: 0.75rem; justify-content: center;">
-        <a href="/" class="btn-primary">Home</a>
-        <a href="/blog" class="btn-secondary">Blog</a>
-      </div>
+      <p style="display: flex; gap: 1.25rem;">
+        <a href="/" class="text-link">Home</a>
+        <a href="/blog" class="text-link">Blog</a>
+      </p>
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -8,82 +8,55 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 >
   <section class="section">
     <div class="container">
-      <div class="about__grid">
-        <div class="about__text">
-          <p class="label reveal" style="margin-bottom: 0.5rem;">About</p>
-          <h1 class="reveal" style="margin-bottom: 1.5rem;">The short version</h1>
+      <h1 style="margin-bottom: 1.5rem;">The short version</h1>
 
-          <div class="prose reveal">
-            <p>
-              I am an actor, clown, and person that is pretty good at problem
-              solving... like really good. I'm not going to lie.
-            </p>
-            <p>
-              But then at some point you realize — oh, the problem is the fun.
-              I did all the things people told me I was supposed to do, and at the
-              end of it I asked, "now what?"
-            </p>
-            <p>
-              That's when I returned home to the small things that bring me delight
-              as I continue to follow my bliss.
-              I can tell you all about the fancy places I worked at and the nice things
-              I've done, but honestly I'm more than all of that put together. And so are you.
-            </p>
-            <p>
-              I'm still coding — because it's fun again, thanks to AI. But I'm also
-              putting my attention back on the things that matter to me, and that's been
-              the art of fucking around and finding out with my merry clown friends.
-            </p>
-            <p>
-              Oh, and I have a dog named Manny.
-            </p>
-          </div>
-        </div>
-        <div class="about__image reveal">
-          <picture>
-            <source type="image/avif" srcset="/images/optimized/photos/luis-sailing-640.avif" />
-            <img
-              src="/images/optimized/photos/luis-sailing-640.jpg"
-              width="1536"
-              height="2048"
-              alt="Luis Meraz sailing"
-              class="about__photo"
-              loading="lazy"
-              decoding="async"
-            />
-          </picture>
-        </div>
+      <div class="prose">
+        <p>
+          I am an actor, clown, and person that is pretty good at problem
+          solving... like really good. I'm not going to lie.
+        </p>
+        <p>
+          But then at some point you realize — oh, the problem is the fun.
+          I did all the things people told me I was supposed to do, and at the
+          end of it I asked, "now what?"
+        </p>
+        <p>
+          That's when I returned home to the small things that bring me delight
+          as I continue to follow my bliss.
+          I can tell you all about the fancy places I worked at and the nice things
+          I've done, but honestly I'm more than all of that put together. And so are you.
+        </p>
+        <p>
+          I'm still coding — because it's fun again, thanks to AI. But I'm also
+          putting my attention back on the things that matter to me, and that's been
+          the art of fucking around and finding out with my merry clown friends.
+        </p>
+        <p>
+          Oh, and I have a dog named Manny.
+        </p>
       </div>
+
+      <picture>
+        <source type="image/avif" srcset="/images/optimized/photos/luis-sailing-640.avif" />
+        <img
+          src="/images/optimized/photos/luis-sailing-640.jpg"
+          width="1536"
+          height="2048"
+          alt="Luis Meraz sailing"
+          class="about__photo"
+          loading="lazy"
+          decoding="async"
+        />
+      </picture>
     </div>
   </section>
 </BaseLayout>
 
 <style>
-  .about__grid {
-    display: grid;
-    grid-template-columns: 1.2fr 0.8fr;
-    gap: clamp(2rem, 4vw, 4rem);
-    align-items: start;
-  }
-
   .about__photo {
-    width: 100%;
+    width: min(100%, 24rem);
     height: auto;
     border-radius: 4px;
-    position: sticky;
-    top: 5rem;
-  }
-
-  @media (max-width: 768px) {
-    .about__grid {
-      grid-template-columns: 1fr;
-    }
-
-    .about__photo {
-      position: static;
-      max-height: 50vh;
-      object-fit: cover;
-      object-position: center 30%;
-    }
+    margin-top: 1rem;
   }
 </style>

--- a/src/pages/acting.astro
+++ b/src/pages/acting.astro
@@ -18,47 +18,37 @@ const photos = [
   description="Luis Meraz is a bilingual Mexican American actor in Los Angeles who acts, improvises, clowns, writes, and produces."
 >
   {/* Hero */}
-  <section class="acting-hero">
-    <div class="acting-hero__image">
-      <picture>
-        <source
-          type="image/avif"
-          srcset="/images/optimized/headshots/luis-meraz-headshot-theatrical-900.avif 900w, /images/optimized/headshots/luis-meraz-headshot-theatrical-1600.avif 1600w"
-          sizes="100vw"
-        />
-        <img
-          src="/images/optimized/headshots/luis-meraz-headshot-theatrical-1600.jpg"
-          srcset="/images/optimized/headshots/luis-meraz-headshot-theatrical-900.jpg 900w, /images/optimized/headshots/luis-meraz-headshot-theatrical-1600.jpg 1600w"
-          sizes="100vw"
-          width="4686"
-          height="5858"
-          alt="Luis Meraz theatrical headshot"
-          class="acting-hero__photo"
-          fetchpriority="high"
-          decoding="async"
-        />
-      </picture>
-      <div class="acting-hero__vignette"></div>
-    </div>
-    <div class="acting-hero__text">
-      <p class="label reveal" style="color: var(--accent-soft);">Actor</p>
-      <h1 class="acting-hero__name reveal">Luis<br>Meraz</h1>
-      <p class="acting-hero__location reveal">Los Angeles</p>
-    </div>
-  </section>
-
-  {/* About */}
-  <section class="section" style="background-color: var(--bg-warm);">
+  <section class="section">
     <div class="container">
-      <h2 class="reveal section-heading">About</h2>
-      <div class="prose reveal" style="max-width: 36rem;">
-        <p>
-          I'm Luis, a bilingual Mexican American actor passionate about storytelling.
-          I used to code at Meta and Lyft. I now inspire people to lead with courage, love,
-          and joy through delight in my craft. I act, improvise, clown, and write.
-          My production company, Do Tell, produces theater and shorts with rave reviews.
-          Beyond entertainment, I surf, sail, DJ, and hike with my dog, Manny.
-        </p>
+      <div class="acting-hero">
+        <picture>
+          <source
+            type="image/avif"
+            srcset="/images/optimized/headshots/luis-meraz-headshot-theatrical-900.avif"
+          />
+          <img
+            src="/images/optimized/headshots/luis-meraz-headshot-theatrical-900.jpg"
+            width="4686"
+            height="5858"
+            alt="Luis Meraz theatrical headshot"
+            class="acting-hero__photo"
+            fetchpriority="high"
+            decoding="async"
+          />
+        </picture>
+        <div>
+          <h1>Luis Meraz</h1>
+          <p class="acting-hero__location meta">Actor &middot; Los Angeles</p>
+          <div class="prose acting-hero__bio">
+            <p>
+              I'm Luis, a bilingual Mexican American actor passionate about storytelling.
+              I used to code at Meta and Lyft. I now inspire people to lead with courage, love,
+              and joy through delight in my craft. I act, improvise, clown, and write.
+              My production company, Do Tell, produces theater and shorts with rave reviews.
+              Beyond entertainment, I surf, sail, DJ, and hike with my dog, Manny.
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   </section>
@@ -66,36 +56,32 @@ const photos = [
   {/* Reels */}
   <section class="section">
     <div class="container">
-      <h2 class="reveal section-heading">Reels</h2>
+      <h2 class="section-heading">Reels</h2>
       <div class="reels-grid">
-        <div class="reveal">
-          <ReelCard
-            vimeoId="1130100675"
-            vimeoHash="7a233520f4"
-            title="Luis Meraz comedy reel"
-            label="Comedy"
-            posterWebp="https://i.vimeocdn.com/video/2074097254-ef6aef6271b526162af24420351be4343403e89c2d7a57b255cb0b6890fe8f01-d?f=webp&mw=960&q=85"
-            posterJpg="https://i.vimeocdn.com/video/2074097254-ef6aef6271b526162af24420351be4343403e89c2d7a57b255cb0b6890fe8f01-d?mw=960&q=85"
-          />
-        </div>
-        <div class="reveal">
-          <ReelCard
-            vimeoId="1130100691"
-            vimeoHash="9eab30c515"
-            title="Luis Meraz dramatic reel"
-            label="Drama"
-            posterWebp="https://i.vimeocdn.com/video/2074097561-483022c7faaf89671864d48981f573f8f00b1d69cd234abe0402ae341108606e-d?f=webp&mw=960&q=85"
-            posterJpg="https://i.vimeocdn.com/video/2074097561-483022c7faaf89671864d48981f573f8f00b1d69cd234abe0402ae341108606e-d?mw=960&q=85"
-          />
-        </div>
+        <ReelCard
+          vimeoId="1130100675"
+          vimeoHash="7a233520f4"
+          title="Luis Meraz comedy reel"
+          label="Comedy"
+          posterWebp="https://i.vimeocdn.com/video/2074097254-ef6aef6271b526162af24420351be4343403e89c2d7a57b255cb0b6890fe8f01-d?f=webp&mw=960&q=85"
+          posterJpg="https://i.vimeocdn.com/video/2074097254-ef6aef6271b526162af24420351be4343403e89c2d7a57b255cb0b6890fe8f01-d?mw=960&q=85"
+        />
+        <ReelCard
+          vimeoId="1130100691"
+          vimeoHash="9eab30c515"
+          title="Luis Meraz dramatic reel"
+          label="Drama"
+          posterWebp="https://i.vimeocdn.com/video/2074097561-483022c7faaf89671864d48981f573f8f00b1d69cd234abe0402ae341108606e-d?f=webp&mw=960&q=85"
+          posterJpg="https://i.vimeocdn.com/video/2074097561-483022c7faaf89671864d48981f573f8f00b1d69cd234abe0402ae341108606e-d?mw=960&q=85"
+        />
       </div>
     </div>
   </section>
 
   {/* Photos */}
-  <section class="section" style="background-color: var(--bg-warm);">
+  <section class="section">
     <div class="container">
-      <h2 class="reveal section-heading">Photos</h2>
+      <h2 class="section-heading">Photos</h2>
       <Gallery photos={photos} />
     </div>
   </section>
@@ -103,106 +89,67 @@ const photos = [
   {/* Resume */}
   <section class="section">
     <div class="container">
-      <h2 class="reveal section-heading">Resume</h2>
-      <div class="reveal">
-        <iframe
-          src="/files/luis-meraz-actor-resume.pdf#toolbar=0"
-          title="Luis Meraz acting resume PDF"
-          class="resume-frame"
-        ></iframe>
-      </div>
-      <div class="reveal" style="text-align: center; margin-top: 1.5rem;">
-        <a href="/files/luis-meraz-actor-resume.pdf" class="btn-secondary">
-          Download Resume &darr;
-        </a>
-      </div>
+      <h2 class="section-heading">Resume</h2>
+      <iframe
+        src="/files/luis-meraz-actor-resume.pdf#toolbar=0"
+        title="Luis Meraz acting resume PDF"
+        class="resume-frame"
+      ></iframe>
+      <p style="margin-top: 1rem;">
+        <a href="/files/luis-meraz-actor-resume.pdf" class="text-link">Download resume</a>
+      </p>
     </div>
   </section>
 
   {/* Contact */}
-  <section class="section" style="background-color: var(--bg-accent); min-height: 40vh; display: flex; align-items: center;">
+  <section class="section">
     <div class="container">
-      <h2 class="reveal" style="font-size: clamp(2.5rem, 7vw, 5.5rem); line-height: 0.95; border: none; padding: 0; margin-bottom: 1rem;">
-        Let's<br>Work Together
-      </h2>
-      <div class="reveal">
-        <p style="font-family: var(--font-heading); font-size: 0.82rem; letter-spacing: 0.1em; color: var(--text-muted); margin-bottom: 0.5rem;">@itsluismeraz</p>
-        <a href="mailto:contact@luismeraz.com" class="contact-email">contact@luismeraz.com</a>
-      </div>
+      <h2 class="section-heading">Let's Work Together</h2>
+      <p class="meta" style="margin-bottom: 0.25rem;">@itsluismeraz</p>
+      <a href="mailto:contact@luismeraz.com" class="text-link">contact@luismeraz.com</a>
     </div>
   </section>
 </BaseLayout>
 
 <style>
   .acting-hero {
-    position: relative;
-    height: 80vh;
-    min-height: 500px;
-    display: flex;
-    align-items: flex-end;
-    overflow: hidden;
-    background-color: #2a2420;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: clamp(1.5rem, 4vw, 2.5rem);
+    align-items: start;
   }
-  .acting-hero__image { position: absolute; inset: -1px; }
-  .acting-hero__photo { width: 100%; height: 100%; object-fit: cover; object-position: center 50%; }
-  .acting-hero__vignette {
-    position: absolute; inset: 0;
-    background: linear-gradient(to bottom, rgba(30,27,24,0.05) 0%, rgba(30,27,24,0) 40%, rgba(30,27,24,0.25) 70%, rgba(30,27,24,0.82) 100%);
+
+  .acting-hero__photo {
+    width: clamp(11rem, 28vw, 16rem);
+    height: auto;
+    border-radius: 4px;
   }
-  .acting-hero__text {
-    position: relative; z-index: 2;
-    padding: 0 clamp(1.5rem, 5vw, 5rem) clamp(2rem, 6vh, 4rem);
-    width: 100%;
-  }
-  .acting-hero__name {
-    font-family: var(--font-display);
-    font-size: clamp(3.5rem, 11vw, 9rem);
-    font-weight: 400; font-style: italic;
-    line-height: 0.9; letter-spacing: -0.02em;
-    color: #fff; margin-bottom: 0.5rem;
-    text-shadow: 0 2px 20px rgba(0,0,0,0.15);
-  }
+
   .acting-hero__location {
-    font-family: var(--font-heading);
-    font-size: 0.78rem; font-weight: 400;
-    letter-spacing: 0.2em; text-transform: uppercase;
-    color: rgba(255,255,255,0.65);
+    margin: 0.5rem 0 1.25rem;
   }
-  .acting-hero .reveal {
-    opacity: 0; transform: translateY(1.5rem);
-    animation: heroReveal 0.8s var(--ease-out) forwards;
-  }
-  @keyframes heroReveal { to { opacity: 1; transform: translateY(0); } }
-  .acting-hero .reveal:nth-child(1) { animation-delay: 0.2s; }
-  .acting-hero .reveal:nth-child(2) { animation-delay: 0.4s; }
-  .acting-hero .reveal:nth-child(3) { animation-delay: 0.6s; }
+
+  .acting-hero__bio p { margin-bottom: 0; }
 
   .reels-grid {
     display: grid;
-    grid-template-columns: 1fr 1fr;
     gap: 1.25rem;
   }
 
   .resume-frame {
-    display: block; width: 100%; max-width: 56rem;
-    height: 360px; margin: 0 auto;
-    border: 0; border-radius: 4px;
+    display: block;
+    width: 100%;
+    height: 480px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
     background-color: #fff;
   }
 
-  .contact-email {
-    font-family: var(--font-display);
-    font-size: clamp(1.4rem, 3.5vw, 2.2rem);
-    font-style: italic;
-    color: var(--accent);
-    border-bottom: 1px solid transparent;
-    transition: border-color 0.3s ease;
-  }
-  .contact-email:hover { border-bottom-color: var(--accent); }
+  @media (max-width: 600px) {
+    .acting-hero {
+      grid-template-columns: 1fr;
+    }
 
-  @media (max-width: 768px) {
-    .acting-hero { height: 70vh; }
-    .reels-grid { grid-template-columns: 1fr; }
-    .resume-frame { height: 280px; }
+    .resume-frame { height: 320px; }
   }
 </style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -66,9 +66,8 @@ const allTags = [...new Set(posts.flatMap(p => p.data.tags))].sort();
 
 <style>
   .blog-listing__title {
-    font-size: clamp(2.2rem, 5vw, 3.8rem);
     margin-bottom: 1.5rem;
-    padding-bottom: 1rem;
+    padding-bottom: 0.75rem;
     border-bottom: 1px solid var(--border);
   }
 
@@ -79,39 +78,40 @@ const allTags = [...new Set(posts.flatMap(p => p.data.tags))].sort();
   .blog-listing__categories {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
   }
 
   .filter-btn {
-    font-family: var(--font-heading);
-    font-size: 0.68rem;
-    font-weight: 600;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    padding: 0.4rem 0.8rem;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
     background: none;
-    border: 1.5px solid var(--border);
-    border-radius: 3px;
+    border: none;
     color: var(--text-muted);
     cursor: pointer;
-    transition: all 0.2s ease;
   }
 
-  .filter-btn:hover { border-color: var(--accent); color: var(--accent); }
-  .filter-btn--active { border-color: var(--accent); color: var(--accent); background-color: var(--bg-surface); }
+  .filter-btn:hover { color: var(--accent); }
+  .filter-btn--active {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
 
   .blog-listing__tags {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.4rem;
+    gap: 0.75rem;
   }
 
-  .filter-tag { cursor: pointer; background: none; }
-  .filter-tag--active { color: var(--accent); border-color: var(--accent); }
+  .filter-tag { cursor: pointer; background: none; border: none; }
+  .filter-tag--active {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
 
   .blog-listing__empty {
-    font-style: italic;
     color: var(--text-muted);
     padding: 2rem 0;
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import PostCard from '../components/PostCard.astro';
-import SignupForm from '../components/SignupForm.astro';
 import { getCollection } from 'astro:content';
 
 const posts = (await getCollection('blog', ({ data }) => !data.draft))
@@ -13,31 +12,27 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
   title="Luis Meraz"
   description="Luis Meraz — actor and builder. Writing about MCP, local-first architecture, and Apple data integration."
 >
-  <section class="hero section">
+  <section class="section">
     <div class="container">
       <div class="hero__grid">
         <div class="hero__text">
-          <p class="label reveal">Clown & Engineer</p>
-          <h1 class="hero__heading reveal">I act, I build,<br>I play.</h1>
-          <p class="hero__description reveal">
-            I write about my many peculiar talents and interests.
+          <h1 class="hero__heading">I act, I build, I play.</h1>
+          <p class="hero__description">
+            Clown &amp; Engineer. I write about my many peculiar talents and interests.
           </p>
-          <div class="hero__ctas reveal">
-            <a href="/newsletter" class="btn-primary">Subscribe</a>
-            <a href="/blog" class="btn-secondary">Read the blog</a>
-          </div>
+          <p class="hero__links">
+            <a href="/blog" class="text-link">Read the blog</a>
+            <a href="/newsletter" class="text-link">Subscribe</a>
+          </p>
         </div>
-        <div class="hero__image reveal">
+        <div class="hero__image">
           <picture>
             <source
               type="image/avif"
-              srcset="/images/optimized/headshots/luis-meraz-headshot-theatrical-900.avif 900w, /images/optimized/headshots/luis-meraz-headshot-theatrical-1600.avif 1600w"
-              sizes="(max-width: 768px) 100vw, 40vw"
+              srcset="/images/optimized/headshots/luis-meraz-headshot-theatrical-900.avif"
             />
             <img
-              src="/images/optimized/headshots/luis-meraz-headshot-theatrical-1600.jpg"
-              srcset="/images/optimized/headshots/luis-meraz-headshot-theatrical-900.jpg 900w, /images/optimized/headshots/luis-meraz-headshot-theatrical-1600.jpg 1600w"
-              sizes="(max-width: 768px) 100vw, 40vw"
+              src="/images/optimized/headshots/luis-meraz-headshot-theatrical-900.jpg"
               width="4686"
               height="5858"
               alt="Luis Meraz theatrical headshot"
@@ -51,79 +46,65 @@ const posts = (await getCollection('blog', ({ data }) => !data.draft))
     </div>
   </section>
 
-  <section class="section" style="background-color: var(--bg-warm);">
+  <section class="section">
     <div class="container">
-      <p class="label reveal" style="margin-bottom: 0.75rem;">Writing</p>
-      <h2 class="reveal section-heading">Latest Posts</h2>
+      <h2 class="section-heading">Latest Posts</h2>
       {posts.map(post => (
-        <div class="reveal">
-          <PostCard
-            title={post.data.title}
-            description={post.data.description}
-            pubDate={post.data.pubDate}
-            tags={post.data.tags}
-            category={post.data.category}
-            readingTime={post.data.readingTime}
-            slug={post.id}
-          />
-        </div>
+        <PostCard
+          title={post.data.title}
+          description={post.data.description}
+          pubDate={post.data.pubDate}
+          tags={post.data.tags}
+          category={post.data.category}
+          readingTime={post.data.readingTime}
+          slug={post.id}
+        />
       ))}
-      <div class="reveal" style="margin-top: 1.5rem;">
-        <a href="/blog" class="btn-secondary">All posts &rarr;</a>
-      </div>
+      <p style="margin-top: 1.5rem;">
+        <a href="/blog" class="text-link">All posts &rarr;</a>
+      </p>
     </div>
   </section>
 </BaseLayout>
 
 <style>
-  .hero {
-    padding: clamp(3rem, 8vh, 6rem) 0;
-  }
-
   .hero__grid {
     display: grid;
-    grid-template-columns: 1.2fr 0.8fr;
-    gap: clamp(2rem, 4vw, 4rem);
+    grid-template-columns: 1fr auto;
+    gap: clamp(1.5rem, 4vw, 3rem);
     align-items: center;
   }
 
   .hero__heading {
-    font-size: clamp(2.5rem, 6vw, 4rem);
-    margin-bottom: 1rem;
+    margin-bottom: 0.75rem;
   }
 
   .hero__description {
-    font-size: 1.05rem;
     color: var(--text-muted);
-    line-height: 1.7;
-    margin-bottom: 1.5rem;
+    margin-bottom: 1rem;
     max-width: 32rem;
   }
 
-
-  .hero__ctas {
+  .hero__links {
     display: flex;
-    gap: 0.75rem;
+    gap: 1.25rem;
   }
 
   .hero__photo {
-    width: 100%;
+    width: clamp(9rem, 22vw, 12rem);
     height: auto;
     border-radius: 4px;
     object-fit: cover;
     aspect-ratio: 3 / 4;
   }
 
-  @media (max-width: 768px) {
+  @media (max-width: 600px) {
     .hero__grid {
       grid-template-columns: 1fr;
     }
 
-    .hero__image { order: -1; }
-
     .hero__photo {
-      max-height: 50vh;
-      object-position: center 30%;
+      width: 12rem;
     }
   }
 </style>

--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -13,24 +13,24 @@ const recentPosts = (await getCollection('blog', ({ data }) => !data.draft))
   description="Subscribe to Luis Meraz's newsletter — posts on MCP, Apple integration, local-first architecture, and indie software."
 >
   <section class="section">
-    <div class="container" style="max-width: 36rem;">
-      <h1 class="reveal" style="margin-bottom: 0.75rem;">Newsletter</h1>
-      <div class="prose reveal">
+    <div class="container">
+      <h1 style="margin-bottom: 0.75rem;">Newsletter</h1>
+      <div class="prose">
         <p>
           I'll write you quarterly about all the fun things I'm up to and how to join the fun.
         </p>
         <p><strong>Let's make the world fun again.</strong></p>
       </div>
-      <div class="reveal" style="margin: 2rem 0;">
+      <div style="margin: 2rem 0;">
         <SignupForm heading="" description="" />
       </div>
       {recentPosts.length > 0 && (
-        <div class="reveal">
-          <p class="label" style="margin-bottom: 0.75rem;">Recent posts</p>
-          <ul style="list-style: none;">
+        <div>
+          <h2 style="font-size: 1.15rem; margin-bottom: 0.75rem;">Recent posts</h2>
+          <ul>
             {recentPosts.map(post => (
               <li style="margin-bottom: 0.5rem;">
-                <a href={`/blog/${post.id}`} style="color: var(--accent); font-style: italic;">
+                <a href={`/blog/${post.id}`} class="text-link">
                   {post.data.title}
                 </a>
               </li>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -27,11 +27,10 @@ const { tag, posts } = Astro.props;
 >
   <section class="section">
     <div class="container">
-      <p class="label" style="margin-bottom: 0.5rem;">Tag</p>
-      <h1 class="section-heading">{tag}</h1>
-      <p style="color: var(--text-muted); margin-bottom: 1.5rem;">
+      <h1 class="section-heading">#{tag}</h1>
+      <p class="meta" style="margin-bottom: 1.5rem;">
         {posts.length} {posts.length === 1 ? 'post' : 'posts'}
-        &middot; <a href="/blog" style="color: var(--accent);">View all posts</a>
+        &middot; <a href="/blog" class="text-link">View all posts</a>
       </p>
 
       {posts.map(post => (

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -14,88 +14,50 @@ const projects = [
   title="Tools"
   description="Things Luis Meraz has built for fun and some profit."
 >
-  <section class="section tools-hero">
+  <section class="section">
     <div class="container">
-      <p class="label reveal">Tools</p>
-      <h1 class="tools-hero__title reveal">Things I've Built for<br>Fun and Some Profit</h1>
-      <p class="tools-hero__tags reveal">
+      <h1 style="margin-bottom: 0.5rem;">Things I've Built for Fun and Some Profit</h1>
+      <p class="meta" style="margin-bottom: 2rem;">
         APIs &middot; CLIs &middot; Apps &middot; AI &middot; MCP &middot; and more
       </p>
-    </div>
-  </section>
 
-  <section class="section" style="background-color: var(--bg-warm);">
-    <div class="container">
-      <div class="project-gallery">
+      <ul>
         {projects.map(project => (
-          <div class="project-card reveal">
-            <div class="project-card__header">
-              <h2 class="project-card__name">{project.name}</h2>
-              <span class="project-card__status">{project.status}</span>
+          <li class="project">
+            <div class="project__header">
+              <h2 class="project__name">{project.name}</h2>
+              <span class="project__status meta">{project.status}</span>
             </div>
-            <p class="project-card__description">{project.description}</p>
-          </div>
+            <p class="project__description">{project.description}</p>
+          </li>
         ))}
-      </div>
+      </ul>
     </div>
   </section>
 </BaseLayout>
 
 <style>
-  .tools-hero { padding: clamp(3rem, 8vh, 6rem) 0; }
-  .tools-hero__title { font-size: clamp(2.5rem, 6vw, 4.5rem); margin-bottom: 1.25rem; }
-  .tools-hero__tags {
-    color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-    letter-spacing: 0.05em;
+  .project {
+    padding: 1.25rem 0;
+    border-top: 1px solid var(--border);
   }
 
-  .project-gallery {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 1.25rem;
-  }
-
-  .project-card {
-    padding: 1.5rem;
-    background: var(--bg-surface);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    transition: border-color 0.3s ease;
-  }
-
-  .project-card:hover { border-color: var(--accent); }
-
-  .project-card__header {
+  .project__header {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
-    margin-bottom: 0.75rem;
+    gap: 1rem;
+    margin-bottom: 0.4rem;
   }
 
-  .project-card__name {
-    font-size: 1.3rem;
-    margin: 0;
-    border: none;
-    padding: 0;
+  .project__name {
+    font-size: 1.15rem;
   }
 
-  .project-card__status {
-    font-family: var(--font-heading);
-    font-size: 0.58rem;
-    font-weight: 600;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    padding: 0.2rem 0.5rem;
-    background: var(--accent);
-    color: #fff;
-    border-radius: 2px;
-    white-space: nowrap;
-  }
+  .project__status { white-space: nowrap; }
 
-  .project-card__description {
-    font-size: 0.92rem;
+  .project__description {
+    font-size: 0.95rem;
     color: var(--text-muted);
     line-height: 1.6;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,37 +1,28 @@
 /* ── Tokens (Light) ────────────────────────────── */
 :root {
-  --bg: #faf6f1;
-  --bg-warm: #f2ebe2;
-  --bg-surface: #ede5da;
-  --bg-accent: #e8cdb5;
-  --text: #1e1b18;
-  --text-muted: #6b6259;
-  --accent: #c7623d;
-  --accent-hover: #a94f2e;
-  --accent-soft: #e8926e;
-  --border: rgba(30, 27, 24, 0.12);
+  --bg: #faf7f2;
+  --bg-surface: #f1ece3;
+  --text: #211d19;
+  --text-muted: #6f6659;
+  --accent: #a84b28;
+  --accent-hover: #8c3d20;
+  --border: rgba(33, 29, 25, 0.15);
   --focus-ring: var(--accent);
-  --font-display: 'Instrument Serif', serif;
-  --font-heading: 'Syne', sans-serif;
-  --font-body: 'Source Serif 4', serif;
+  --font-body: 'Source Serif 4', Georgia, serif;
   --font-mono: ui-monospace, 'SF Mono', Menlo, monospace;
-  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
-  --content-width: 72rem;
-  --reading-width: 80ch;
+  --content-width: 44rem;
+  --reading-width: 70ch;
 }
 
 /* ── Tokens (Dark) ─────────────────────────────── */
 html[data-theme="dark"] {
-  --bg: #1a1714;
-  --bg-warm: #211e1a;
-  --bg-surface: #2a2520;
-  --bg-accent: #3a2e24;
-  --text: #e8e0d6;
-  --text-muted: #9a8e82;
-  --accent: #e8926e;
-  --accent-hover: #f0a580;
-  --accent-soft: #c7623d;
-  --border: rgba(232, 224, 214, 0.1);
+  --bg: #1c1916;
+  --bg-surface: #292420;
+  --text: #e9e2d8;
+  --text-muted: #a2968a;
+  --accent: #e08d64;
+  --accent-hover: #eba57f;
+  --border: rgba(233, 226, 216, 0.16);
 }
 
 /* ── Reset ─────────────────────────────────────── */
@@ -40,20 +31,17 @@ html[data-theme="dark"] {
 html {
   min-height: 100%;
   background-color: var(--bg);
-  scroll-behavior: smooth;
   -webkit-font-smoothing: antialiased;
 }
 
 body {
   min-height: 100%;
   font-family: var(--font-body);
-  font-weight: 300;
+  font-weight: 400;
   font-size: 1.05rem;
   line-height: 1.7;
   color: var(--text);
   background-color: var(--bg);
-  overflow-x: hidden;
-  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 main { display: block; }
@@ -64,17 +52,15 @@ ul { list-style: none; }
 
 /* ── Typography ────────────────────────────────── */
 h1, h2, h3 {
-  font-family: var(--font-display);
-  font-weight: 400;
-  font-style: italic;
-  line-height: 1.1;
-  letter-spacing: -0.01em;
+  font-family: var(--font-body);
+  font-weight: 600;
+  line-height: 1.2;
   color: var(--text);
 }
 
-h1 { font-size: clamp(2.5rem, 5vw, 3.8rem); }
-h2 { font-size: clamp(2rem, 4vw, 3rem); }
-h3 { font-size: clamp(1.4rem, 2.5vw, 1.8rem); }
+h1 { font-size: clamp(1.9rem, 4vw, 2.5rem); }
+h2 { font-size: clamp(1.35rem, 3vw, 1.7rem); }
+h3 { font-size: 1.15rem; }
 
 code, pre {
   font-family: var(--font-mono);
@@ -92,25 +78,21 @@ code, pre {
 }
 
 .section {
-  position: relative;
-  padding: clamp(2.5rem, 6vh, 4.5rem) 0;
+  padding: clamp(2rem, 5vh, 3.5rem) 0;
 }
 
 /* ── Section headings ──────────────────────────── */
 .section-heading {
   margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
+  padding-bottom: 0.75rem;
   border-bottom: 1px solid var(--border);
 }
 
-/* ── Labels ────────────────────────────────────── */
-.label {
-  font-family: var(--font-heading);
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--accent-soft);
+/* ── Meta text (dates, categories, counts) ─────── */
+.meta {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
 }
 
 /* ── Focus ─────────────────────────────────────── */
@@ -127,9 +109,7 @@ code, pre {
   z-index: 10000;
   padding: 0.75rem 1rem;
   background-color: var(--accent);
-  color: #fff;
-  font-family: var(--font-heading);
-  font-weight: 600;
+  color: var(--bg);
   text-decoration: none;
   transform: translateY(-200%);
   transition: transform 0.2s ease;
@@ -137,71 +117,33 @@ code, pre {
 
 .skip-link:focus { transform: translateY(0); }
 
-/* ── Grain overlay ─────────────────────────────── */
-.grain {
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  pointer-events: none;
-  opacity: 0.04;
-  background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwBAMAAAClLOS0AAAAElBMVEUAAAAAAAAAAAAAAAAAAAAAAADgKxmiAAAABnRSTlMFBQUFBQVMIbLVAAAASElEQVQ4y2MYBaNgGAMWIxgYmBgYGBkYGJkYGFmANAsDIwuQZmFhZGZiYWRmYmJgZmRmYGZgZmBhYGBgYWFiYRgFo2AUAAB2BwJ/cMOjNgAAAABJRU5ErkJggg==");
-  background-size: 48px;
-}
-
-/* ── Scroll reveal ─────────────────────────────── */
-.reveal {
-  opacity: 0;
-  transform: translateY(1.5rem);
-  transition: opacity 0.7s var(--ease-out), transform 0.7s var(--ease-out);
-}
-
-.reveal.is-visible {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-/* ── Buttons ───────────────────────────────────── */
-.btn-primary {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1.5rem;
-  font-family: var(--font-heading);
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #fff;
-  background-color: var(--accent);
-  border: 1.5px solid var(--accent);
-  border-radius: 3px;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-}
-
-.btn-primary:hover { background-color: var(--accent-hover); }
-
-.btn-secondary {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1.5rem;
-  font-family: var(--font-heading);
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+/* ── Links & buttons ───────────────────────────── */
+.text-link {
   color: var(--accent);
-  background: transparent;
-  border: 1.5px solid var(--accent);
-  border-radius: 3px;
-  cursor: pointer;
-  transition: background-color 0.3s ease, color 0.3s ease;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
 }
 
-.btn-secondary:hover {
+.text-link:hover { color: var(--accent-hover); }
+
+.btn-primary {
+  display: inline-block;
+  padding: 0.5rem 1.1rem;
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--bg);
+  background-color: var(--text);
+  border: 1px solid var(--text);
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.btn-primary:hover {
   background-color: var(--accent);
-  color: #fff;
+  border-color: var(--accent);
+  color: var(--bg);
 }
 
 /* ── Blog prose ────────────────────────────────── */
@@ -211,10 +153,15 @@ code, pre {
 .prose ul, .prose ol { margin-bottom: 1.5rem; padding-left: 1.5rem; }
 .prose li { margin-bottom: 0.5rem; list-style: disc; }
 .prose ol li { list-style: decimal; }
-.prose a { color: var(--accent); border-bottom: 1px solid transparent; transition: border-color 0.3s ease; }
-.prose a:hover { border-bottom-color: var(--accent); }
+.prose a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+.prose a:hover { color: var(--accent-hover); }
 .prose blockquote {
-  border-left: 3px solid var(--accent-soft);
+  border-left: 3px solid var(--border);
   padding-left: 1.25rem;
   margin: 1.5rem 0;
   color: var(--text-muted);
@@ -228,7 +175,6 @@ code, pre {
 }
 .prose pre {
   background-color: var(--bg-surface);
-  border-left: 3px solid var(--accent);
   border-radius: 4px;
   padding: 1.25rem;
   overflow-x: auto;
@@ -243,27 +189,13 @@ code, pre {
   font-size: 0.88em;
 }
 
-/* ── Tag pills ─────────────────────────────────── */
+/* ── Tags ──────────────────────────────────────── */
 .tag {
   font-family: var(--font-mono);
-  font-size: 0.65rem;
-  padding: 0.2rem 0.6rem;
-  border: 1px solid var(--border);
-  border-radius: 2px;
+  font-size: 0.78rem;
   color: var(--text-muted);
-  transition: color 0.2s ease, border-color 0.2s ease;
 }
 
-.tag:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-}
+.tag::before { content: '#'; }
 
-/* ── Responsive ────────────────────────────────── */
-@media (max-width: 768px) {
-  .section { padding: clamp(2rem, 4vh, 3rem) 0; }
-}
-
-@media (max-width: 480px) {
-  .section { padding: 2rem 0; }
-}
+a.tag:hover, button.tag:hover { color: var(--accent); }


### PR DESCRIPTION
## Summary

Removes the generic AI-generated aesthetic from the site theme and simplifies to a quiet, typographic design:

- **Fonts**: 3 families → 1. Drops Instrument Serif (italic display) and Syne (uppercase micro-labels); everything now uses Source Serif 4, with system mono for dates/tags.
- **Removed decoration**: grain/noise overlay, scroll-reveal animations, uppercase letterspaced kicker labels and buttons, alternating section background stripes, image hover-zooms, and the full-bleed vignette hero + giant italic CTA on /acting.
- **New look**: single warm-paper background per theme, narrower 44rem reading column, plain underlined links, roman headings.
- **Accessibility**: fixes dark-mode WCAG contrast on the subscribe button hover and skip link (2.6:1 → 6.8:1).

All copy is unchanged. Dark mode, blog filters, Vimeo reel lazy-embed, RSS, and the Buttondown signup form keep working.

## Test plan

- `npm run build` passes (11 pages)
- Visually verified every page in light/dark and desktop/mobile viewports
- Multi-agent adversarial review of the diff (slop-residue, correctness, accessibility); all 6 confirmed findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)