### PR TITLE
feat: add theater reel to acting page

### DIFF
--- a/src/pages/acting.astro
+++ b/src/pages/acting.astro
@@ -74,6 +74,14 @@ const photos = [
           posterWebp="https://i.vimeocdn.com/video/2074097561-483022c7faaf89671864d48981f573f8f00b1d69cd234abe0402ae341108606e-d?f=webp&mw=960&q=85"
           posterJpg="https://i.vimeocdn.com/video/2074097561-483022c7faaf89671864d48981f573f8f00b1d69cd234abe0402ae341108606e-d?mw=960&q=85"
         />
+        <ReelCard
+          vimeoId="1206593117"
+          vimeoHash="c6631ddb6f"
+          title="Luis Meraz theater reel"
+          label="Theater"
+          posterWebp="https://i.vimeocdn.com/video/2175479378-9bdb309c332bb9401d406ce39bbc8a798f65def2c1642483656672ff4c190f11-d?f=webp&mw=960&q=85"
+          posterJpg="https://i.vimeocdn.com/video/2175479378-9bdb309c332bb9401d406ce39bbc8a798f65def2c1642483656672ff4c190f11-d?mw=960&q=85"
+        />
       </div>
     </div>
   </section>
@@ -133,6 +141,7 @@ const photos = [
 
   .reels-grid {
     display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
     gap: 1.25rem;
   }
 
@@ -149,6 +158,8 @@ const photos = [
     .acting-hero {
       grid-template-columns: 1fr;
     }
+
+    .reels-grid { grid-template-columns: 1fr; }
 
     .resume-frame { height: 320px; }
   }


### PR DESCRIPTION
## What changed

- Added a third `ReelCard` to the Reels section on the acting page for the theater reel (Twelfth Night — Sebastian), Vimeo `1206593117` with unlisted hash `c6631ddb6f`.
- Laid the reels grid out three across on desktop; it collapses to a single column under the existing 600px breakpoint.

## Why

The acting page had comedy and drama reels only; this adds the theater reel in the same format.

## Notes for review

- Poster URLs come from Vimeo's oEmbed thumbnail for the video, using the same `mw=960&q=85` webp/jpg pattern as the existing cards.
- Verified locally in the dev server: posters load, click-to-play swaps in the player with `h=c6631ddb6f&autoplay=1&dnt=1`, and mobile stacks to one column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)