### PR TITLE
fix: add Acting to blog category enum

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -8,6 +8,7 @@ export const CATEGORIES = [
   'MCP Ecosystem',
   'Build Log',
   'Philosophy',
+  'Acting',
 ] as const;
 
 const blog = defineCollection({


### PR DESCRIPTION
Fixes the failed Pages deploy on main ([run 28625889752](https://github.com/lmeraz/lmeraz.github.io/actions/runs/28625889752)): the currency post uses `category: "Acting"`, which wasn't in the `CATEGORIES` enum, so `astro build` failed schema validation. Adds `Acting` to the enum; local build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)